### PR TITLE
ci: 배포 전 테스트 게이트 추가, PR 트리거 및 브라우저 캐싱 적용

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,27 @@ jobs:
 
       - run: npm ci
 
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium --with-deps
+
+      - name: Install Playwright dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+
       - run: npm run build
+
+      - name: Run tests
+        run: npx playwright test
+        env:
+          CI: true
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -2,6 +2,7 @@ name: Playwright Tests
 
 on:
   push:
+  pull_request:
 
 jobs:
   test:
@@ -16,7 +17,20 @@ jobs:
 
       - run: npm ci
 
-      - run: npx playwright install chromium --with-deps
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium --with-deps
+
+      - name: Install Playwright dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       - run: npm run build
 

--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test:performance": "npm run preview -- --port 4173 & sleep 5 && playwright test tests/performance; TEST_EXIT=$?; pkill -f 'vite preview' 2>/dev/null || true; exit $TEST_EXIT",
-    "test:performance:report": "npm run preview -- --port 4173 & sleep 5 && playwright test tests/performance --reporter=html; TEST_EXIT=$?; pkill -f 'vite preview' 2>/dev/null || true; exit $TEST_EXIT",
-    "test:performance:ui": "npm run preview -- --port 4173 & sleep 3 && npx playwright test tests/performance --ui; pkill -f 'vite preview' 2>/dev/null || true",
-    "test:performance:headed": "npm run preview -- --port 4173 & sleep 5 && playwright test tests/performance --headed; TEST_EXIT=$?; pkill -f 'vite preview' 2>/dev/null || true; exit $TEST_EXIT",
-    "test:state": "npm run preview -- --port 4173 & sleep 5 && playwright test tests/performance/04-detailed-state.spec.js; TEST_EXIT=$?; pkill -f 'vite preview' 2>/dev/null || true; exit $TEST_EXIT",
-    "test:state:headed": "npm run preview -- --port 4173 & sleep 5 && playwright test tests/performance/04-detailed-state.spec.js --headed; TEST_EXIT=$?; pkill -f 'vite preview' 2>/dev/null || true; exit $TEST_EXIT"
+    "test:performance": "npx playwright test",
+    "test:performance:report": "npx playwright test --reporter=html",
+    "test:performance:ui": "npx playwright test --ui",
+    "test:performance:headed": "npx playwright test --headed",
+    "test:state": "npx playwright test tests/performance/04-detailed-state.spec.js",
+    "test:state:headed": "npx playwright test tests/performance/04-detailed-state.spec.js --headed"
   },
   "dependencies": {
     "ol": "^10.8.0",


### PR DESCRIPTION
- deploy.yml: 빌드 후 Playwright 테스트 통과해야 배포되도록 변경
- playwright.yml: pull_request 트리거 추가로 PR status check 지원
- 양 워크플로우에 Playwright 브라우저 캐싱 적용 (actions/cache@v4)
- package.json: 수동 프로세스 관리(& sleep, pkill) 제거,
  Playwright webServer 설정 활용으로 안정성 개선

https://claude.ai/code/session_016ikHDAupLLwmzVJAWEf4Xa