### PR TITLE
fix: 모바일에서 WebGL 타일 파이프라인 대신 image 파이프라인 강제 사용

### DIFF
--- a/src/cogImageLayer.js
+++ b/src/cogImageLayer.js
@@ -5,7 +5,8 @@ import { intersects, getIntersection } from 'ol/extent'
 import { fromUrl as tiffFromUrl, Pool } from 'geotiff'
 import { detectBands, getMinMaxFromOverview } from './cogLayer.js'
 
-const pool = new Pool(4)
+let pool
+try { pool = new Pool(4) } catch { /* worker unavailable – decode on main thread */ }
 
 function fillPixelData(px, rasters, bandInfo, stats, pixelCount) {
   if (bandInfo.type === 'rgb') {

--- a/src/main.js
+++ b/src/main.js
@@ -150,7 +150,7 @@ const loadCOG = async (url) => {
       }
       let cogLayer, cogSource, extent
 
-      const pipeline = RENDER_PIPELINE === 'tile' && !supportsWebGLFloat() ? 'image' : RENDER_PIPELINE
+      const pipeline = RENDER_PIPELINE === 'tile' && (isMobile() || !supportsWebGLFloat()) ? 'image' : RENDER_PIPELINE
 
       if (pipeline === 'image') {
         const resolutionMultiplier = isMobile() && !mobileHighQuality ? MOBILE_RES_MULTIPLIER : 1


### PR DESCRIPTION
모바일 GPU에서 WebGLTileLayer의 float 텍스처 렌더링이 에러 없이
실패하여 영상이 보이지 않는 문제를 수정. 모바일 기기에서는 항상
Canvas 기반 image 파이프라인을 사용하도록 변경하여 해상도 조절,
화질 토글 등 모바일 전용 기능도 정상 작동하도록 함.

Pool 생성 실패 시 메인 스레드 디코딩으로 fallback 처리 추가.

https://claude.ai/code/session_01AwmeAKe3xkHuc5G4JFWYqD