### PR TITLE
Refactor CI/CD workflows: separate deploy and test jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,40 @@ jobs:
 
       - run: npm ci
 
+      - run: npm run build
+
+      - name: Verify build output
+        run: |
+          test -f dist/index.html || { echo "ERROR: dist/index.html not found"; exit 1; }
+          test -d dist/assets || { echo "ERROR: dist/assets not found"; exit 1; }
+
+      - name: Preserve preview deployments
+        run: |
+          if git fetch origin gh-pages --depth=1 2>/dev/null; then
+            git worktree add gh-pages-branch origin/gh-pages
+            if [ -d gh-pages-branch/preview ]; then
+              cp -r gh-pages-branch/preview dist/preview
+            fi
+            git worktree remove gh-pages-branch
+          fi
+
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
       - name: Cache Playwright browsers
         id: playwright-cache
         uses: actions/cache@v4
@@ -45,18 +79,3 @@ jobs:
         run: npx playwright test
         env:
           CI: true
-
-      - name: Preserve preview deployments
-        run: |
-          if git fetch origin gh-pages --depth=1 2>/dev/null; then
-            git worktree add gh-pages-branch origin/gh-pages
-            if [ -d gh-pages-branch/preview ]; then
-              cp -r gh-pages-branch/preview dist/preview
-            fi
-            git worktree remove gh-pages-branch
-          fi
-
-      - uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -29,6 +29,22 @@ jobs:
       - name: Build for preview
         run: npx vite build --base /COGnito/preview/pr-${{ github.event.pull_request.number }}/
 
+      - name: Verify build output
+        run: |
+          PR_NUM="${{ github.event.pull_request.number }}"
+          BASE="/COGnito/preview/pr-${PR_NUM}/"
+
+          # 필수 파일 존재 확인
+          test -f dist/index.html || { echo "ERROR: dist/index.html not found"; exit 1; }
+          test -f dist/style.json || { echo "ERROR: dist/style.json not found"; exit 1; }
+          test -f dist/sw.js || { echo "ERROR: dist/sw.js not found"; exit 1; }
+          test -d dist/assets || { echo "ERROR: dist/assets not found"; exit 1; }
+
+          # HTML 내 에셋 경로가 preview base path를 사용하는지 확인
+          grep -q "${BASE}assets/" dist/index.html || { echo "ERROR: asset paths do not use preview base path"; exit 1; }
+
+          echo "Build verification passed: all files present, base path correct (${BASE})"
+
       - uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Restructured the GitHub Actions workflows to improve CI/CD pipeline organization and add build verification steps.

## Key Changes

- **Separated deploy and test jobs** in `deploy.yml`: The deployment logic (build and GitHub Pages publishing) is now in its own `deploy` job, while testing remains in a separate `test` job. This allows them to run independently and improves workflow clarity.

- **Added build verification** in both workflows:
  - `deploy.yml`: Verifies presence of `dist/index.html` and `dist/assets/`
  - `preview-deploy.yml`: Comprehensive verification including `index.html`, `style.json`, `sw.js`, `assets/` directory, and validates that asset paths use the correct preview base path

- **Moved preview deployment preservation logic** from the `test` job to the `deploy` job in `deploy.yml`, ensuring it runs as part of the deployment process rather than after tests.

## Implementation Details

The build verification steps use shell test commands to ensure critical files exist and, in the preview deployment case, validates that the HTML file contains correctly formatted asset paths with the preview base path. This prevents deployment of incomplete or misconfigured builds.

The workflow separation allows for more granular control over job dependencies and execution, making the CI/CD pipeline more maintainable and easier to debug.

https://claude.ai/code/session_01UEpuwWXV3An1hCnPeXzP22