### PR TITLE
Add concurrency control to Playwright workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,6 +5,10 @@ on:
     branches-ignore: [main]
   pull_request:
 
+concurrency:
+  group: playwright-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Added concurrency configuration to the Playwright GitHub Actions workflow to prevent multiple runs from executing simultaneously and cancel in-progress runs when new ones are triggered.

## Key Changes
- Added `concurrency` block to the workflow configuration
- Set concurrency group to `playwright-${{ github.event.pull_request.number || github.ref }}` to group runs by pull request number or git ref
- Enabled `cancel-in-progress: true` to automatically cancel previous runs when a new workflow is triggered

## Implementation Details
This change ensures that only one Playwright test run executes at a time for a given pull request or branch, improving resource efficiency and preventing race conditions. When a new commit is pushed to a PR or branch, any previously running workflow will be cancelled before the new one starts.

https://claude.ai/code/session_01KZvA6YmpPUMUgTeZPmWYGJ