### PR TITLE
Rebrand to COGnito and refactor header layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>COG Viewer - OpenLayers</title>
+  <title>COGnito</title>
   <link rel="preconnect" href="https://storage.googleapis.com">
   <link rel="preconnect" href="https://tiles.versatiles.org">
   <style>
@@ -52,6 +52,7 @@
       color: white;
       opacity: 0.9;
       transition: opacity 0.2s;
+      vertical-align: middle;
     }
 
     .github-link:hover {
@@ -418,14 +419,9 @@
     <header class="header">
       <div class="header-top">
         <div>
-          <h1>🛰️ COG Viewer <span id="app-version" style="font-size:0.65rem;font-weight:400;opacity:0.7;vertical-align:middle"></span></h1>
+          <h1>COGnito <span id="app-version" style="font-size:0.65rem;font-weight:400;opacity:0.7;vertical-align:middle"></span> <a href="https://github.com/conaonda/COGnito" target="_blank" rel="noopener noreferrer" class="github-link" title="GitHub"><svg width="20" height="20" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a></h1>
           <p>Hurricane Harvey SkySat 영상 | OpenLayers 10.x + Vite</p>
         </div>
-        <a href="https://github.com/conaonda/COGnito" target="_blank" rel="noopener noreferrer" class="github-link" title="GitHub">
-          <svg width="24" height="24" viewBox="0 0 16 16" fill="currentColor">
-            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/>
-          </svg>
-        </a>
       </div>
       <div class="header-url">
         <input type="text" id="cog-url-input" placeholder="COG URL 입력">

--- a/src/authUI.js
+++ b/src/authUI.js
@@ -14,8 +14,7 @@ export function initAuthUI() {
   const authContainer = document.createElement('div')
   authContainer.className = 'auth-container'
 
-  const githubLink = headerTop.querySelector('.github-link')
-  headerTop.insertBefore(authContainer, githubLink)
+  headerTop.appendChild(authContainer)
 
   renderLoggedOut(authContainer)
 

--- a/src/main.js
+++ b/src/main.js
@@ -65,7 +65,7 @@ const initMap = async () => {
     controls: defaultControls({
       zoom: true,
       rotate: true,
-      attribution: true
+      attribution: false
     })
   })
 


### PR DESCRIPTION
## Summary
This PR rebrands the application from "COG Viewer" to "COGnito" and reorganizes the header layout by moving the GitHub link inline with the title. Additionally, minor styling and configuration adjustments are made.

## Key Changes
- **Branding**: Updated page title and main heading from "COG Viewer - OpenLayers" to "COGnito"
- **Header Layout**: Moved GitHub link from a separate element in the header-top to be inline with the h1 title, reducing layout complexity
- **Styling**: Added `vertical-align: middle` to `.github-link` class for better alignment with text
- **Auth UI**: Simplified auth container insertion by appending to header-top instead of inserting before the GitHub link
- **Map Configuration**: Disabled attribution control in the map initialization (changed `attribution: true` to `attribution: false`)

## Implementation Details
- The GitHub link SVG was resized from 24x24 to 20x20 to better fit inline with the heading
- The auth container now appends to the end of header-top, eliminating the dependency on GitHub link positioning
- These changes improve the visual hierarchy and simplify the DOM structure while maintaining all functionality

https://claude.ai/code/session_012nhXfQzaPd5AtdHKVSMx4T