### PR TITLE
chore: 1.0.0 이전 feat을 patch bump로 변경

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,7 @@
     ".": {
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": false
+      "bump-patch-for-minor-pre-major": true
     }
   }
 }


### PR DESCRIPTION
## Summary
- `bump-patch-for-minor-pre-major`를 `true`로 변경하여 1.0.0 이전에는 `feat:` 커밋도 patch 버전만 올리도록 설정
- minor 버전은 로드맵의 주요 기능 단위와 일치시키기 위함

## Test plan
- [ ] 머지 후 Release Please가 v0.2.2로 릴리스 PR을 생성하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)