### PR TITLE
fix: README 뱃지를 shields.io 동적 뱃지로 교체

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 OpenLayers 기반 Cloud Optimized GeoTIFF (COG) 영상 가시화 웹 애플리케이션
 
 ![Version](https://img.shields.io/github/package-json/v/conaonda/COGnito)
-![OpenLayers](https://img.shields.io/badge/OpenLayers-10.x-blue)
-![Vite](https://img.shields.io/badge/Vite-6.x-646CFF)
+![OpenLayers](https://img.shields.io/github/package-json/dependency-version/conaonda/COGnito/ol?label=OpenLayers&color=blue)
+![Vite](https://img.shields.io/github/package-json/dependency-version/conaonda/COGnito/dev/vite?label=Vite&color=646CFF)
+![Supabase](https://img.shields.io/github/package-json/dependency-version/conaonda/COGnito/@supabase/supabase-js?label=Supabase&color=3ECF8E)
 
 **라이브 데모:** https://conaonda.github.io/COGnito/
 


### PR DESCRIPTION
## Summary
- OpenLayers, Vite 정적 뱃지를 shields.io `package-json/dependency-version` 동적 뱃지로 교체
- Supabase 뱃지 추가
- 의존성 버전 업데이트 시 뱃지가 자동으로 반영됨

Closes #38

## Test plan
- [ ] shields.io 뱃지가 올바른 버전을 표시하는지 확인 (OpenLayers ^10.8.0, Vite ^6.1.0, Supabase ^2.97.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)