### PR TITLE
ci: 비기능 변경 PR의 파이프라인 스킵 구성

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -3,7 +3,15 @@ name: Playwright Tests
 on:
   push:
     branches-ignore: [main]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.gitignore'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.gitignore'
 
 concurrency:
   group: playwright-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -3,6 +3,10 @@ name: Preview Deployment
 on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.gitignore'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- `playwright.yml`: `push`, `pull_request` 트리거에 `paths-ignore` 추가 (`**.md`, `LICENSE`, `.gitignore`)
- `preview-deploy.yml`: `pull_request` 트리거에 `paths-ignore` 추가 (동일 패턴)
- 문서만 변경하는 PR에서 불필요한 Playwright 테스트 및 프리뷰 배포 실행 방지

Closes #41

## Test plan
- [ ] 문서만 변경하는 PR에서 playwright, preview-deploy 워크플로우가 스킵되는지 확인
- [ ] 코드 변경이 포함된 PR에서는 정상 실행되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)