### PR TITLE
chore: supabase/.temp/ 을 .gitignore에 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ test-results/
 .env.local
 .env.*.local
 
+# Supabase local cache
+supabase/.temp/
+
 # System files
 .sisyphus/
 tmp/


### PR DESCRIPTION
## Summary
- `supabase link` 실행 시 생성되는 로컬 캐시 디렉터리를 .gitignore에 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)