### PR TITLE
fix: STAC 검색 결과 카탈로그 등록 시 로그인 검증 추가

### DIFF
--- a/src/registerUI.js
+++ b/src/registerUI.js
@@ -212,8 +212,14 @@ function openRegisterModal(meta) {
 
 /**
  * STAC 또는 외부에서 메타데이터가 미리 채워진 등록 모달 열기
+ * 로그인 상태를 확인하여 미인증 사용자는 로그인 안내 표시
  */
-export function openRegisterModalWithMeta(meta) {
+export async function openRegisterModalWithMeta(meta) {
+  const session = await getSession()
+  if (!session?.user) {
+    alert('카탈로그에 등록하려면 먼저 로그인해주세요.')
+    return
+  }
   window.currentCogMeta = { ...window.currentCogMeta, ...meta }
   openRegisterModal(window.currentCogMeta)
 }


### PR DESCRIPTION
openRegisterModalWithMeta에서 getSession() 호출로 로그인 상태를
확인하여, 미인증 사용자가 STAC 검색 결과를 카탈로그에 등록하려
할 때 로그인 안내 메시지를 표시합니다.

Closes #58

https://claude.ai/code/session_0195D6wZ8EPYovES6Z1V6XCa