### PR TITLE
fix: Navigator LockManager 타임아웃으로 인한 카탈로그 조회 실패 해결

### DIFF
--- a/src/supabase.js
+++ b/src/supabase.js
@@ -5,6 +5,9 @@ const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
 
 export const supabase = supabaseUrl && supabaseAnonKey
   ? createClient(supabaseUrl, supabaseAnonKey, {
-      auth: { flowType: 'pkce' }
+      auth: {
+        flowType: 'pkce',
+        lock: async (_name, _acquireTimeout, fn) => fn()
+      }
     })
   : null


### PR DESCRIPTION
Supabase auth의 navigator.locks API 사용을 no-op lock으로 대체하여
토큰 갱신 시 발생하는 10초 타임아웃 에러를 방지한다.

Closes #62

https://claude.ai/code/session_018SEN7fd57CjzkDhggjTLPh