### PR TITLE
fix: Planetary Computer COG 에셋 SAS 토큰 서명 추가

### DIFF
--- a/src/stac.js
+++ b/src/stac.js
@@ -91,10 +91,30 @@ export function extractStacItemMeta(item) {
   meta.cogUrl = cogUrl
   meta.thumbnail_url = thumbnailUrl
 
-  // 컬렉션 → 태그
+  // 컬렉션
   if (item.collection) {
+    meta.collection = item.collection
     meta.tags = [item.collection]
   }
 
   return meta
+}
+
+/**
+ * Planetary Computer 에셋 URL에 SAS 토큰 서명
+ * PC가 아닌 URL이거나 토큰 발급 실패 시 원본 URL 반환
+ */
+export async function signPlanetaryComputerUrl(url, collectionId) {
+  if (!url || !url.includes('.blob.core.windows.net')) return url
+  try {
+    const res = await fetch(
+      `https://planetarycomputer.microsoft.com/api/sas/v1/token/${collectionId}`
+    )
+    if (!res.ok) return url
+    const { token } = await res.json()
+    const separator = url.includes('?') ? '&' : '?'
+    return `${url}${separator}${token}`
+  } catch {
+    return url
+  }
 }

--- a/src/stacUI.js
+++ b/src/stacUI.js
@@ -1,4 +1,4 @@
-import { STAC_PRESETS, searchStac, getStacCollections, extractStacItemMeta } from './stac.js'
+import { STAC_PRESETS, searchStac, getStacCollections, extractStacItemMeta, signPlanetaryComputerUrl } from './stac.js'
 
 /**
  * STAC 검색 UI 초기화
@@ -127,15 +127,17 @@ export function initStacUI(onViewCog, onRegisterCog, getMapBbox) {
         `
 
         if (meta.cogUrl) {
-          card.querySelector('.stac-view-btn').addEventListener('click', (e) => {
+          card.querySelector('.stac-view-btn').addEventListener('click', async (e) => {
             e.stopPropagation()
             panel.classList.remove('open')
-            onViewCog(meta.cogUrl)
+            const signedUrl = await signPlanetaryComputerUrl(meta.cogUrl, meta.collection)
+            onViewCog(signedUrl)
           })
 
-          card.querySelector('.stac-register-btn').addEventListener('click', (e) => {
+          card.querySelector('.stac-register-btn').addEventListener('click', async (e) => {
             e.stopPropagation()
-            onRegisterCog(meta)
+            const signedUrl = await signPlanetaryComputerUrl(meta.cogUrl, meta.collection)
+            onRegisterCog({ ...meta, cogUrl: signedUrl })
           })
         }
 


### PR DESCRIPTION
## Summary
- Planetary Computer STAC 검색 결과의 COG URL(Azure Blob Storage)에 SAS 토큰 서명 추가
- 클릭 시점에 on-demand로 토큰 발급 (TTL ~1시간)
- PC가 아닌 URL이거나 토큰 발급 실패 시 원본 URL로 graceful fallback

## Test plan
- [ ] Planetary Computer에서 sentinel-2-l2a 검색 → "뷰어에서 보기" 클릭 → COG 정상 로드 확인
- [ ] Earth Search 검색 → signing 없이 기존대로 정상 동작 확인
- [ ] 토큰 API 실패 시 에러 없이 fallback 동작 확인

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)