### PR TITLE
feat: STAC 공간 검색 조건 상세화 (포함/교차 옵션)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1055,6 +1055,10 @@
           <option value="">컬렉션 선택...</option>
         </select>
         <label><input type="checkbox" id="stac-use-bbox"> 현재 맵 범위로 검색</label>
+        <select id="stac-spatial-filter" style="display:none">
+          <option value="contains">포함 (영상이 맵 범위를 포함)</option>
+          <option value="intersects">교차 (맵 범위와 겹침)</option>
+        </select>
         <div class="stac-date-row">
           <input type="date" id="stac-date-from" title="시작일">
           <input type="date" id="stac-date-to" title="종료일">

--- a/src/stacUI.js
+++ b/src/stacUI.js
@@ -16,8 +16,14 @@ export function initStacUI(onViewCog, onRegisterCog, getMapBbox) {
   const customUrlInput = panel.querySelector('#stac-custom-url')
   const collectionSelect = panel.querySelector('#stac-collection')
   const bboxCheckbox = panel.querySelector('#stac-use-bbox')
+  const spatialFilter = panel.querySelector('#stac-spatial-filter')
   const dateFrom = panel.querySelector('#stac-date-from')
   const dateTo = panel.querySelector('#stac-date-to')
+
+  // bbox 체크 시 공간 필터 드롭다운 표시
+  bboxCheckbox.addEventListener('change', () => {
+    spatialFilter.style.display = bboxCheckbox.checked ? '' : 'none'
+  })
   const searchBtn = panel.querySelector('#stac-search-btn')
   const resultList = panel.querySelector('#stac-results')
   const statusEl = panel.querySelector('#stac-status')
@@ -94,7 +100,17 @@ export function initStacUI(onViewCog, onRegisterCog, getMapBbox) {
       }
 
       const result = await searchStac(params)
-      const features = result.features || []
+      let features = result.features || []
+
+      // 공간 필터: "포함" 모드일 때 맵 범위를 완전히 포함하는 영상만 표시
+      if (bboxCheckbox.checked && spatialFilter.value === 'contains' && params.bbox) {
+        const [mMinLon, mMinLat, mMaxLon, mMaxLat] = params.bbox
+        features = features.filter(item => {
+          const b = item.bbox
+          if (!b || b.length < 4) return false
+          return b[0] <= mMinLon && b[1] <= mMinLat && b[2] >= mMaxLon && b[3] >= mMaxLat
+        })
+      }
 
       statusEl.textContent = `${features.length}개 결과`
 


### PR DESCRIPTION
## Summary
- "현재 맵 범위로 검색" 체크 시 공간 필터 드롭다운 표시
- **포함(Contains)**: 영상 bbox가 맵 범위를 완전히 포함하는 결과만 표시 (기본값)
- **교차(Intersects)**: 기존 동작 유지 (겹치기만 하면 표시)
- 클라이언트 측 bbox 비교, 외부 라이브러리 불필요

Closes #54

## Test plan
- [ ] "현재 맵 범위로 검색" 체크 시 공간 필터 드롭다운이 나타나는지 확인
- [ ] "포함" 선택 시 맵 범위를 완전히 포함하는 영상만 결과에 표시되는지 확인
- [ ] "교차" 선택 시 겹치는 영상이 모두 표시되는지 확인
- [ ] 체크 해제 시 드롭다운이 숨겨지는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)