### PR TITLE
feat: 테스트 그룹화/선택적 실행 및 Supabase 브랜딩 가이드

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,11 +55,37 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
+
+      - name: Detect changed paths
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            core:
+              - 'src/main.js'
+              - 'index.html'
+              - 'vite.config.js'
+            cog:
+              - 'src/cogLayer.js'
+              - 'src/cogImageLayer.js'
+              - 'src/AffineTileLayer.js'
+            stac:
+              - 'src/stac.js'
+              - 'src/stacUI.js'
+            auth:
+              - 'src/auth.js'
+              - 'src/authUI.js'
+            ci:
+              - '.github/workflows/**'
+              - 'playwright.config.js'
+              - 'playwright.auth.config.js'
 
       - run: npm ci
 
@@ -84,12 +110,27 @@ jobs:
           VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
           VITE_CORS_PROXY_URL: https://cog-cors-proxy.conaonda.workers.dev
 
-      - name: Run tests
+      # core 또는 CI 변경 시 전체 테스트, 아니면 관련 그룹만 실행
+      - name: Run all tests
+        if: steps.changes.outputs.core == 'true' || steps.changes.outputs.ci == 'true'
         run: npx playwright test
         env:
           CI: true
 
+      - name: Run COG rendering tests only
+        if: steps.changes.outputs.core != 'true' && steps.changes.outputs.ci != 'true' && steps.changes.outputs.cog == 'true'
+        run: npx playwright test --project=cog-rendering
+        env:
+          CI: true
+
+      - name: Run core tests for STAC changes
+        if: steps.changes.outputs.core != 'true' && steps.changes.outputs.ci != 'true' && steps.changes.outputs.stac == 'true'
+        run: npx playwright test --project=core
+        env:
+          CI: true
+
       - name: Run auth tests
+        if: steps.changes.outputs.auth == 'true' || steps.changes.outputs.core == 'true' || steps.changes.outputs.ci == 'true'
         run: npx playwright test --config=playwright.auth.config.js
         env:
           CI: true

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -69,7 +69,39 @@ Supabase Dashboard → **Authentication → URL Configuration**:
 | Redirect URLs | `https://<your-username>.github.io/COGnito/` |
 | | `http://localhost:5173/COGnito/` |
 
-## 6. CORS 프록시 설정 (선택사항)
+## 6. Supabase 브랜딩 설정 (선택사항)
+
+기본 설정에서는 OAuth 로그인 화면과 인증 메일에 Supabase 도메인이 노출됩니다 (#33).
+사용자에게 COGnito 브랜드로 표시하려면 아래 설정을 변경하세요.
+
+### 6-1. 프로젝트 표시 이름
+
+Supabase Dashboard → **Settings → General**:
+- **Project Name**을 `COGnito`로 변경
+
+### 6-2. 이메일 템플릿 커스터마이징
+
+Supabase Dashboard → **Authentication → Email Templates**:
+- 각 템플릿(Confirm, Invite, Magic Link, Reset Password)에서 발신자 이름과 내용을 수정
+
+### 6-3. 커스텀 SMTP (선택)
+
+기본 `noreply@mail.app.supabase.io` 대신 자체 도메인 이메일을 사용하려면:
+
+Supabase Dashboard → **Settings → Auth → SMTP Settings**:
+- Enable Custom SMTP
+- SMTP Host, Port, User, Password 설정
+- Sender email: `noreply@yourdomain.com`
+
+### 6-4. 커스텀 도메인 (유료)
+
+OAuth 리다이렉트 URL에서 `xxx.supabase.co`를 자체 도메인으로 변경하려면:
+
+Supabase Dashboard → **Settings → Custom Domains**:
+- 유료 플랜에서 커스텀 도메인 설정 가능
+- DNS CNAME 레코드 추가 필요
+
+## 7. CORS 프록시 설정 (선택사항)
 
 외부 COG 서버가 CORS를 허용하지 않을 때 Cloudflare Worker 프록시를 사용합니다.
 
@@ -89,7 +121,7 @@ VITE_CORS_PROXY_URL=https://your-worker-name.workers.dev
 
 > 프록시 없이도 CORS를 허용하는 COG 서버의 영상은 정상 로드됩니다.
 
-## 7. 로컬 개발 실행
+## 8. 로컬 개발 실행
 
 ```bash
 npm run dev
@@ -97,9 +129,9 @@ npm run dev
 
 브라우저에서 `http://localhost:5173/COGnito/` 로 접속합니다.
 
-## 8. GitHub Pages 배포
+## 9. GitHub Pages 배포
 
-### 8-1. GitHub Secrets 등록
+### 9-1. GitHub Secrets 등록
 
 `setup-supabase.sh`에서 자동 등록을 시도하지만, Codespaces 등 토큰 권한이 제한된 환경에서는 실패할 수 있습니다. 그 경우 웹 UI에서 직접 등록하세요.
 
@@ -113,14 +145,14 @@ npm run dev
 | `VITE_SUPABASE_URL` | `https://xxx.supabase.co` (Supabase Project URL) |
 | `VITE_SUPABASE_ANON_KEY` | Supabase Dashboard → Settings → API의 `anon` `public` 키 |
 
-### 8-2. GitHub Pages 활성화
+### 9-2. GitHub Pages 활성화
 
 Repository → **Settings → Pages**:
 - Source: **GitHub Actions**
 
 `main` 브랜치에 push하면 `.github/workflows/deploy.yml`이 자동으로 빌드 및 배포합니다.
 
-## 9. 트러블슈팅
+## 10. 트러블슈팅
 
 ### `.env` 파일이 없다는 에러
 
@@ -145,7 +177,7 @@ cp .env.example .env
 ### COG 영상 로드 실패 (CORS 에러)
 
 - 브라우저 개발자 도구 → Network 탭에서 CORS 에러 확인
-- CORS 프록시가 설정되어 있는지 확인 (6번 참조)
+- CORS 프록시가 설정되어 있는지 확인 (7번 참조)
 - 프록시 Worker가 정상 배포되었는지 `curl` 등으로 확인
 
 ### 빌드 실패

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -60,6 +60,42 @@ COGnito 개발 중 발견된 이슈와 해결 방법을 기록합니다.
 3. 검색 시 AOI가 설정되어 있으면 `intersects` 파라미터 사용 (bbox보다 우선)
 4. "초기화" 버튼으로 AOI 삭제
 
-**주의**: `createBox()`는 ol/interaction/Draw의 static 메서드. `Draw.createBox()` 형식으로 호출.
+**주의**: `createBox()`는 `ol/interaction/Draw`에서 named export. `import { createBox } from 'ol/interaction/Draw'` 로 import.
 
 **관련 코드**: `src/stacUI.js`, `src/stac.js`
+
+---
+
+## #53: 테스트 그룹화 및 변경 기반 선택적 테스트 실행
+
+**배경**: push마다 모든 Playwright 테스트가 일괄 실행되어 CI 시간이 길어짐.
+
+**해결**:
+1. Playwright config에 4개 프로젝트로 테스트 그룹화:
+   - `core`: 페이지 로드 (01-page-load)
+   - `map-interaction`: 팬/줌 (02-map-pan, 03-map-zoom)
+   - `cog-rendering`: COG 렌더링 (05~08)
+   - `state`: 상태 스냅샷 (04-detailed-state)
+2. CI에서 `dorny/paths-filter`로 변경 경로 감지:
+   - `src/main.js`, `index.html` 변경 → 전체 테스트
+   - `src/cogLayer.js` 등 변경 → `cog-rendering` 그룹만
+   - `src/auth*.js` 변경 → auth 테스트만
+3. auth 테스트는 별도 config(`playwright.auth.config.js`)로 유지
+
+**관련 코드**: `playwright.config.js`, `.github/workflows/deploy.yml`
+
+---
+
+## #33: OAuth/인증 메일에 Supabase 도메인 노출
+
+**증상**: OAuth 로그인 시 `xxx.supabase.co`가 표시되고, 인증 메일 발신자가 Supabase로 표시됨.
+
+**해결**: 코드 변경 아님. Supabase Dashboard 설정으로 해결:
+1. **Settings → General**: 프로젝트 이름을 `COGnito`로 변경
+2. **Authentication → Email Templates**: 이메일 내용 커스터마이징
+3. **(선택) Settings → Auth → SMTP**: 커스텀 SMTP로 자체 발신 주소 사용
+4. **(유료) Settings → Custom Domains**: 커스텀 도메인 설정
+
+자세한 가이드는 `docs/SETUP.md` 6번 참조.
+
+**관련 코드**: 없음 (인프라 설정)

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,53 +1,67 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const sharedUse = {
+  baseURL: 'http://localhost:4173/COGnito/',
+  trace: 'on-first-retry',
+  screenshot: 'only-on-failure',
+  video: 'retain-on-failure',
+  launchOptions: {
+    headless: true,
+    args: [
+      '--disable-background-timer-throttling',
+      '--disable-backgrounding-occluded-windows',
+      '--disable-renderer-backgrounding',
+      '--disable-dev-shm-usage',
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+      '--no-first-run',
+      '--no-zygote'
+    ]
+  }
+}
+
 export default defineConfig({
   testDir: './tests/performance',
-  
+
   fullyParallel: false,
-  
+
   forbidOnly: !!process.env.CI,
-  
+
   retries: process.env.CI ? 2 : 0,
-  
+
   workers: 1,
-  
+
   reporter: [
     ['html', { outputFolder: 'playwright-report' }],
     ['json', { outputFile: 'test-results/performance-results.json' }],
     ['list']
   ],
-  
+
   use: {
-    baseURL: 'http://localhost:4173/COGnito/',
-    
-    trace: 'on-first-retry',
-    
-    screenshot: 'only-on-failure',
-    video: 'retain-on-failure',
-    
-    launchOptions: {
-      headless: true,
-      args: [
-        '--disable-background-timer-throttling',
-        '--disable-backgrounding-occluded-windows',
-        '--disable-renderer-backgrounding',
-        '--disable-dev-shm-usage',
-        '--no-sandbox',
-        '--disable-setuid-sandbox',
-        '--no-first-run',
-        '--no-zygote'
-      ]
-    }
+    ...sharedUse,
   },
-  
+
   projects: [
     {
-      name: 'chromium',
-      use: { 
-        ...devices['Desktop Chrome'],
-        viewport: { width: 1280, height: 720 }
-      },
-    }
+      name: 'core',
+      testMatch: /01-page-load/,
+      use: { ...devices['Desktop Chrome'], viewport: { width: 1280, height: 720 } },
+    },
+    {
+      name: 'map-interaction',
+      testMatch: /0[23]-map-(pan|zoom)/,
+      use: { ...devices['Desktop Chrome'], viewport: { width: 1280, height: 720 } },
+    },
+    {
+      name: 'cog-rendering',
+      testMatch: /0[5678]-/,
+      use: { ...devices['Desktop Chrome'], viewport: { width: 1280, height: 720 } },
+    },
+    {
+      name: 'state',
+      testMatch: /04-detailed-state/,
+      use: { ...devices['Desktop Chrome'], viewport: { width: 1280, height: 720 } },
+    },
   ],
 
   timeout: 120 * 1000,


### PR DESCRIPTION
## Summary
- Playwright config에 4개 프로젝트로 테스트 그룹화 (#53)
- CI에서 dorny/paths-filter로 변경 기반 선택적 테스트 실행
- Supabase 브랜딩 설정 가이드 문서화 (#33)

## Test plan
- [ ] `npx playwright test --project=core` 실행 확인
- [ ] `npx playwright test --project=cog-rendering` 실행 확인
- [ ] CI에서 paths-filter가 정상 동작하는지 확인
- [ ] SETUP.md의 Supabase 브랜딩 섹션 내용 확인

Closes #53
Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)