### PR TITLE
chore: bkit 플러그인 로컬 상태 파일 gitignore 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ supabase/.temp/
 # System files
 .sisyphus/
 tmp/
+
+# bkit plugin state
+docs/.bkit-memory.json
+docs/.pdca-status.json
+docs/.pdca-snapshots/


### PR DESCRIPTION
## Summary
- bkit 플러그인이 생성하는 로컬 상태 파일 3건을 `.gitignore`에 추가
  - `docs/.bkit-memory.json`
  - `docs/.pdca-status.json`
  - `docs/.pdca-snapshots/`

## Test plan
- [ ] CI 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)