### PR TITLE
ci: add workflow_dispatch to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- release.yml에 `workflow_dispatch` 트리거 추가
- release-please를 수동 실행할 수 있도록 개선
- PR #90 (v0.3.0 잘못 고정) close 후 재생성 위해 필요

## Context
release-please PR #90이 v0.3.0으로 잘못 고정되어 있어 close함.
이 PR 머지 후 workflow_dispatch로 release-please 재실행하여 올바른 v1.1.0 PR 생성 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)