### PR TITLE
docs: v2.0 로드맵 Plan 및 영상 설명 서비스 Design 문서

### DIFF
--- a/docs/01-plan/features/v2-roadmap.plan.md
+++ b/docs/01-plan/features/v2-roadmap.plan.md
@@ -1,0 +1,342 @@
+# v2-roadmap Planning Document
+
+> **Summary**: v1.0 → v2.0 큐레이션 카탈로그 플랫폼으로의 진화 로드맵
+>
+> **Project**: COGnito
+> **Version**: 1.0.0
+> **Author**: conaonda
+> **Date**: 2026-02-26
+> **Status**: Draft
+
+---
+
+## 1. Overview
+
+### 1.1 Purpose
+
+COGnito를 단순 COG 뷰어/카탈로그에서 **의미 있는 위성영상을 자동으로 선별·설명·큐레이션하는 플랫폼**으로 진화시킨다. 사용자가 STAC에서 직접 검색하는 것보다 COGnito 카탈로그가 더 유용하도록 만든다.
+
+### 1.2 Background
+
+현재 STAC 검색으로 수집되는 영상의 대부분은 사용자에게 의미가 없다:
+- 타일링된 영상의 모서리 (빈 영역이 대부분)
+- 과노출/백색 영상
+- 바다 한가운데 구름만 보이는 영상
+
+로드맵의 "콘텐츠 철학"에 명시된 대로, *"포맷이 맞으면 수집"이 아니라 "사람들과 나눌 가치가 있는 영상"*을 수집해야 한다. 이를 자동화하려면 영상을 이해하고 설명할 수 있는 하위 서비스가 필요하다.
+
+### 1.3 Related Documents
+
+- 로드맵: `docs/ROADMAP.md`
+- 사용자 가이드: `docs/USER_GUIDE.md`
+- 뷰어 강화 Plan: `docs/01-plan/features/viewer-enhancement.plan.md`
+
+---
+
+## 2. Scope
+
+### 2.1 In Scope
+
+- [ ] v1.1: 뷰어 강화 + 안정화 (밴드/컬러맵 UI, HTTP 캐싱, 테스트 커버리지)
+- [ ] v1.2: 영상 설명 서비스 (Image Descriptor) — 독립 백엔드
+- [ ] v1.3: 영상 큐레이션 서비스 (Image Curator) — 자동 수집 파이프라인
+- [ ] v1.4: 큐레이션 카탈로그 UI
+- [ ] v2.0: 큐레이션 플랫폼 완성 + 자동화 + 피드백 루프
+
+### 2.2 Out of Scope
+
+- 자체 위성영상 호스팅 (COG 원본은 외부 소스 유지)
+- 유료 AI API 사용 (Google AI Studio Pro 구독 범위 내에서 운영)
+- 실시간 영상 처리 (배치 처리 기반)
+- 모바일 앱
+
+---
+
+## 3. Milestones
+
+### 3.1 v1.1.0 — 뷰어 강화 + 안정화
+
+현재 진행 중인 이슈들을 정리하고 v2.0 기반을 다진다.
+
+| ID | 항목 | 관련 이슈 | Priority |
+|----|------|-----------|----------|
+| v1.1-01 | 밴드 선택 / 컬러맵 / Min-Max 스트레치 UI | PR #91 | High |
+| v1.1-02 | COG HTTP 요청 캐싱 (URL + Range 키) | #94 | Medium |
+| v1.1-03 | 카탈로그 목록 썸네일 표시 | #95 | Medium |
+| v1.1-04 | v1.0.0 GitHub Release 생성 | #96 | High |
+| v1.1-05 | 테스트 커버리지 수치 제공 | #97 | Medium |
+
+**검증 기준:**
+- 뷰어 컨트롤 (밴드/컬러맵/스트레치) E2E 테스트 통과
+- 카탈로그 목록에 썸네일 표시
+- 테스트 커버리지 리포트 생성 확인
+
+---
+
+### 3.2 v1.2.0 — 영상 설명 서비스 (Image Descriptor)
+
+독립 백엔드 서비스로 영상에 대한 풍부한 설명을 자동 생성한다.
+
+| ID | 항목 | Priority |
+|----|------|----------|
+| v1.2-01 | 독립 백엔드 서비스 프로젝트 구성 (Python) | High |
+| v1.2-02 | 역지오코딩 모듈 (좌표 → 국가/지역/행정구역) | High |
+| v1.2-03 | 피복분류 모듈 (좌표 → OSM/VersaTiles 벡터지도 조회) | High |
+| v1.2-04 | Gemini Vision 영상 설명 생성 (썸네일 + 좌표 + 촬영일자 입력) | High |
+| v1.2-05 | 웹 검색 기반 시기별 맥락 조사 모듈 | Medium |
+| v1.2-06 | API 엔드포인트 설계 (REST) | High |
+| v1.2-07 | COGnito 프론트엔드 연동 (설명 표시) | Medium |
+
+**아키텍처:**
+```
+[COGnito Frontend]
+       │
+       ▼
+[Image Descriptor API]  (Python, 독립 서비스)
+       │
+       ├── Reverse Geocoder (Nominatim / 자체 캐시)
+       ├── Land Cover Lookup (OSM Overpass / VersaTiles)
+       ├── Image Describer (Google AI Studio — Gemini Vision)
+       └── Context Researcher (웹 검색 API)
+```
+
+**입력/출력:**
+```
+입력:
+  - thumbnail: 최하위 피라미드 이미지 (base64 or URL)
+  - coordinates: [lon, lat] 또는 bbox
+  - captured_at: 촬영일자 (ISO 8601)
+
+출력:
+  - description: 자연어 설명문
+  - location:
+      country: 국가
+      region: 지역/행정구역
+      place_name: 지명
+  - land_cover:
+      classes: [{type, percentage}]  # OSM/VersaTiles 벡터 기반
+  - context:
+      events: [{title, date, source_url}]  # 시기별 맥락
+```
+
+**검증 기준:**
+- 좌표 입력 → 국가/지역 반환 정확도 95%+
+- 피복분류 벡터 조회 응답 시간 < 2초
+- Gemini Vision 설명 생성 성공률 90%+
+- API 엔드포인트 호출 → 전체 설명 JSON 반환
+
+---
+
+### 3.3 v1.3.0 — 영상 큐레이션 서비스 (Image Curator)
+
+설명 서비스의 출력을 기반으로 영상의 의미도를 판정하고 자동 수집한다.
+
+| ID | 항목 | Priority |
+|----|------|----------|
+| v1.3-01 | 영상 품질 필터 (모서리/백색/해양구름 탐지) | High |
+| v1.3-02 | 의미도 점수 산정 로직 설계 | High |
+| v1.3-03 | 자동 수집 파이프라인 (STAC → Descriptor → Curator → DB) | High |
+| v1.3-04 | 수집 스케줄러 (배치 처리) | Medium |
+| v1.3-05 | 수집 로그/모니터링 | Medium |
+
+**품질 필터 (reject 기준):**
+- 유효 픽셀 비율 < 70% (타일 모서리)
+- 평균 밝기 > 임계값 (과노출/백색)
+- 피복분류 결과가 "해양" 95%+ 이고 구름 커버리지 높음
+
+**의미도 점수 (0–100):**
+```
+score = w1 * location_interest      # 인구밀집/관광지/주요시설 근접도
+      + w2 * event_relevance        # 해당 시기 이벤트 존재 여부
+      + w3 * visual_diversity       # 피복분류 다양성
+      + w4 * image_quality          # 해상도, 구름 커버리지
+      + w5 * temporal_uniqueness    # 동일 지역 기존 영상과의 시간 차이
+```
+
+**검증 기준:**
+- 모서리/백색/해양구름 영상 필터링 정확도 90%+
+- 수집 파이프라인 end-to-end 동작 (STAC 검색 → 설명 생성 → 점수 산정 → DB 저장)
+- 점수 50 미만 영상 자동 reject
+
+---
+
+### 3.4 v1.4.0 — 큐레이션 카탈로그 UI
+
+큐레이션된 영상의 풍부한 정보를 사용자에게 제공하는 UI.
+
+| ID | 항목 | Priority |
+|----|------|----------|
+| v1.4-01 | 영상 설명문/맥락 표시 UI (카드 확장 또는 상세 페이지) | High |
+| v1.4-02 | 피복분류/지역 정보 시각화 | Medium |
+| v1.4-03 | 의미도 점수 기반 정렬/필터 | High |
+| v1.4-04 | "이 영상이 흥미로운 이유" 섹션 | Medium |
+| v1.4-05 | 큐레이션 카탈로그 vs STAC 검색 탭 분리 | Medium |
+
+**검증 기준:**
+- 카탈로그에서 영상 설명/맥락/피복분류 정보 표시
+- 의미도 점수 순 정렬 동작
+- 큐레이션 카탈로그의 영상이 STAC 원시 결과보다 체감 품질 우수
+
+---
+
+### 3.5 v2.0.0 — 큐레이션 플랫폼 완성
+
+| ID | 항목 | Priority |
+|----|------|----------|
+| v2.0-01 | 수집 파이프라인 자동화 + 모니터링 대시보드 | High |
+| v2.0-02 | 사용자 피드백 루프 (좋아요/신고 → 점수 보정) | High |
+| v2.0-03 | 큐레이션 통계 (수집률, reject률, 인기 지역 등) | Medium |
+| v2.0-04 | 전체 안정화 + 문서화 + 릴리스 | High |
+
+**검증 기준:**
+- 자동 수집 파이프라인이 일정 주기로 무인 동작
+- 사용자 좋아요/신고가 향후 수집 점수에 반영
+- 큐레이션 카탈로그 영상 100건+ 확보
+- v2.0 릴리스 완료
+
+---
+
+## 4. Requirements
+
+### 4.1 Functional Requirements
+
+| ID | Requirement | Milestone | Priority |
+|----|-------------|-----------|----------|
+| FR-01 | 좌표+촬영일자 입력 → 역지오코딩 결과 반환 | v1.2 | High |
+| FR-02 | 좌표 기반 피복분류 조회 (OSM/VersaTiles) | v1.2 | High |
+| FR-03 | 썸네일+메타데이터 → Gemini Vision 자연어 설명 생성 | v1.2 | High |
+| FR-04 | 시기+지역 기반 웹 검색 맥락 조사 | v1.2 | Medium |
+| FR-05 | 영상 품질 자동 필터링 (모서리/백색/구름) | v1.3 | High |
+| FR-06 | 의미도 점수 산정 및 수집 판정 | v1.3 | High |
+| FR-07 | STAC → Descriptor → Curator → DB 파이프라인 | v1.3 | High |
+| FR-08 | 큐레이션 정보 UI 표시 | v1.4 | High |
+| FR-09 | 사용자 피드백 기반 점수 보정 | v2.0 | High |
+
+### 4.2 Non-Functional Requirements
+
+| Category | Criteria | Measurement |
+|----------|----------|-------------|
+| 비용 | Gemini Vision — Google AI Studio Pro 구독 범위 내 | 월별 API 호출량 모니터링 |
+| 비용 | 역지오코딩/피복분류 — 무료 서비스 활용 | OSM Nominatim, Overpass API |
+| 성능 | 단일 영상 설명 생성 < 30초 | API 응답 시간 측정 |
+| 가용성 | 수집 파이프라인 실패 시 재시도 + 알림 | 로그 모니터링 |
+| 확장성 | 일 1000건 이상 영상 처리 가능 | 배치 처리 벤치마크 |
+
+---
+
+## 5. Risks and Mitigation
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| Google AI Studio API 할당량 초과 | High | Medium | 배치 처리 속도 제한, 캐싱, 일일 할당량 모니터링 |
+| OSM Nominatim 사용 정책 위반 (과다 요청) | Medium | Medium | 자체 캐시 구축, 요청 속도 제한 (1 req/sec) |
+| 의미도 점수의 주관성 | Medium | High | 사용자 피드백 루프로 지속 보정, 초기에는 보수적 기준 |
+| 독립 백엔드 인프라 비용 | Medium | Low | 초기 최소 인프라 (단일 서버), 트래픽에 따라 스케일 |
+| Gemini Vision 설명 품질 불안정 | Medium | Medium | 프롬프트 최적화, 설명 품질 샘플링 검증 |
+
+---
+
+## 6. Architecture Considerations
+
+### 6.1 Project Level
+
+| Level | Selected |
+|-------|:--------:|
+| **Starter** (COGnito Frontend — 기존) | ✅ |
+| **Dynamic** (Image Descriptor Backend — 신규) | ✅ |
+
+COGnito 프론트엔드는 기존 Vite + OpenLayers 유지. 신규 백엔드 서비스는 별도 프로젝트로 구성.
+
+### 6.2 Key Architectural Decisions
+
+| Decision | Options | Selected | Rationale |
+|----------|---------|----------|-----------|
+| 백엔드 언어 | Python / Node.js | Python | Gemini SDK, 지리공간 라이브러리 풍부 |
+| 역지오코딩 | Nominatim / Google Geocoding / Photon | Nominatim (자체 캐시) | 무료, OSM 기반, 셀프호스팅 가능 |
+| 피복분류 | OSM Overpass / VersaTiles / CORINE | OSM + VersaTiles | 무료, 글로벌 커버리지, 벡터 기반 |
+| 영상 설명 LLM | Gemini Vision / Claude / GPT-4V | Gemini Vision | Google AI Studio Pro 구독 중, 비용 무료 |
+| 웹 검색 | Google Search API / SerpAPI / DuckDuckGo | 검토 필요 | 무료/저비용 옵션 우선 |
+| 프론트↔백엔드 | REST / GraphQL | REST | 단순, 기존 패턴과 일관 |
+
+### 6.3 서비스 아키텍처
+
+```
+┌──────────────────────────────────────────────────────┐
+│ COGnito Frontend (Vite + OpenLayers)                 │
+│   ├── 카탈로그 UI (큐레이션 정보 표시)                    │
+│   ├── 뷰어 (밴드/컬러맵 컨트롤)                         │
+│   └── Supabase Client (Auth, DB)                     │
+└──────────────┬───────────────────────────────────────┘
+               │ REST API
+┌──────────────▼───────────────────────────────────────┐
+│ Image Descriptor Service (Python)                     │
+│   ├── /describe  — 영상 설명 생성                       │
+│   ├── /geocode   — 역지오코딩                           │
+│   ├── /landcover — 피복분류 조회                        │
+│   └── /context   — 시기별 맥락 조사                     │
+├───────────────────────────────────────────────────────┤
+│ Image Curator Service (Python, 동일 서비스 또는 모듈)    │
+│   ├── /evaluate  — 의미도 점수 산정                     │
+│   ├── /filter    — 품질 필터                            │
+│   └── /pipeline  — 수집 파이프라인 트리거                 │
+├───────────────────────────────────────────────────────┤
+│ External Dependencies                                 │
+│   ├── Google AI Studio (Gemini Vision)                │
+│   ├── OSM Nominatim (역지오코딩)                       │
+│   ├── OSM Overpass / VersaTiles (피복분류)             │
+│   ├── Web Search API (맥락 조사)                       │
+│   └── STAC APIs (Earth Search, Planetary Computer)    │
+└───────────────────────────────────────────────────────┘
+               │
+┌──────────────▼───────────────────────────────────────┐
+│ Supabase (DB + Auth + Storage)                        │
+│   ├── cog_images (+ description, score 컬럼 추가)      │
+│   ├── image_descriptions (설명 상세)                    │
+│   └── curation_logs (수집/필터 이력)                    │
+└───────────────────────────────────────────────────────┘
+```
+
+---
+
+## 7. Convention Prerequisites
+
+### 7.1 Existing Project Conventions
+
+- [x] `CLAUDE.md` 코딩 컨벤션 존재
+- [ ] 백엔드 서비스 컨벤션 미정 (Python 프로젝트 신규)
+- [x] Playwright 테스트 구성
+- [ ] 백엔드 테스트 프레임워크 미정
+
+### 7.2 신규 결정 필요 사항
+
+| Category | 결정 필요 사항 | Priority |
+|----------|---------------|:--------:|
+| 백엔드 프레임워크 | FastAPI / Flask / Django | High |
+| 패키지 관리 | pip / poetry / uv | Medium |
+| 백엔드 배포 | Docker / 클라우드 서비스 | High |
+| 모노레포 vs 멀티레포 | 프론트/백엔드 분리 방식 | High |
+
+### 7.3 Environment Variables (신규)
+
+| Variable | Purpose | Scope |
+|----------|---------|-------|
+| `GOOGLE_AI_API_KEY` | Gemini Vision API 키 | Backend |
+| `SUPABASE_SERVICE_KEY` | Supabase 서비스 키 (백엔드 DB 접근) | Backend |
+| `NOMINATIM_URL` | Nominatim 엔드포인트 (셀프호스팅 시) | Backend |
+
+---
+
+## 8. Next Steps
+
+1. [ ] v1.1 마일스톤 이슈 정리 및 진행 (현재 PR #91 포함)
+2. [ ] v1.2 영상 설명 서비스 Design 문서 작성 (`/pdca design image-descriptor`)
+3. [ ] 백엔드 기술 스택 최종 결정 (프레임워크, 배포 방식)
+4. [ ] ROADMAP.md 업데이트 (v2.0 마일스톤 반영)
+
+---
+
+## Version History
+
+| Version | Date | Changes | Author |
+|---------|------|---------|--------|
+| 0.1 | 2026-02-26 | Initial draft | conaonda |

--- a/docs/02-design/features/image-descriptor.design.md
+++ b/docs/02-design/features/image-descriptor.design.md
@@ -1,0 +1,561 @@
+# Image Descriptor Service Design Document
+
+> **Summary**: COG 영상의 좌표/촬영일자/썸네일로부터 자연어 설명, 위치정보, 피복분류, 시기별 맥락을 생성하는 독립 백엔드 서비스
+>
+> **Project**: COGnito
+> **Version**: 1.0.0 → v1.2.0 target
+> **Author**: conaonda
+> **Date**: 2026-02-26
+> **Status**: Draft
+> **Planning Doc**: [v2-roadmap.plan.md](../01-plan/features/v2-roadmap.plan.md)
+
+---
+
+## 1. Overview
+
+### 1.1 Design Goals
+
+- COG 영상에 대한 풍부한 메타데이터를 자동 생성하는 독립 백엔드 서비스 구축
+- 무료/저비용 외부 서비스 활용으로 운영 비용 최소화
+- COGnito 프론트엔드와 REST API로 연동
+- 향후 큐레이션 서비스(v1.3)의 기반이 되는 설명 데이터 제공
+
+### 1.2 Design Principles
+
+- **비용 효율**: 무료 서비스 우선 (Nominatim, Overpass), 유료는 기존 구독(Google AI Studio) 범위 내
+- **모듈화**: 역지오코딩, 피복분류, 영상설명, 맥락조사를 독립 모듈로 분리
+- **캐싱 우선**: 동일 좌표/지역에 대한 반복 요청 최소화
+- **점진적 실패**: 개별 모듈 실패 시 나머지 결과는 정상 반환
+
+---
+
+## 2. Architecture
+
+### 2.1 Component Diagram
+
+```
+┌───────────────────────────────────────────────────┐
+│ COGnito Frontend (Vite + OpenLayers)              │
+│   catalog.js / catalogUI.js                       │
+└──────────────┬────────────────────────────────────┘
+               │ POST /api/describe
+               ▼
+┌───────────────────────────────────────────────────┐
+│ Image Descriptor Service (Python / FastAPI)        │
+│                                                    │
+│  ┌─────────────┐  ┌──────────────┐                │
+│  │  Geocoder    │  │ LandCover    │                │
+│  │  Module      │  │ Module       │                │
+│  │ (Nominatim)  │  │ (Overpass)   │                │
+│  └──────┬───────┘  └──────┬───────┘                │
+│         │                 │                        │
+│  ┌──────▼─────────────────▼──────┐                 │
+│  │       Response Composer       │                 │
+│  └──────▲─────────────────▲──────┘                 │
+│         │                 │                        │
+│  ┌──────┴───────┐  ┌──────┴───────┐                │
+│  │  Describer   │  │  Context     │                │
+│  │  Module      │  │  Researcher  │                │
+│  │ (Gemini)     │  │ (Web Search) │                │
+│  └──────────────┘  └──────────────┘                │
+│                                                    │
+│  ┌─────────────────────────────────┐               │
+│  │  Cache Layer (SQLite / Redis)   │               │
+│  └─────────────────────────────────┘               │
+└──────────────┬────────────────────────────────────┘
+               │ Supabase Service Key
+               ▼
+┌───────────────────────────────────────────────────┐
+│ Supabase DB                                        │
+│   cog_images (기존) + image_descriptions (신규)    │
+└───────────────────────────────────────────────────┘
+```
+
+### 2.2 Data Flow
+
+```
+1. 프론트엔드 → POST /api/describe {thumbnail, coordinates, captured_at}
+2. Geocoder: coordinates → Nominatim reverse → {country, region, place_name}
+3. LandCover: coordinates → Overpass is_in query → {landuse classes}
+4. Describer: thumbnail + geocode + landcover → Gemini Vision → {description}
+5. Context: place_name + captured_at → Web Search → {events}
+6. Composer: 모든 결과 조합 → JSON 응답
+7. DB 저장: image_descriptions 테이블에 캐시
+```
+
+### 2.3 Dependencies
+
+| Component | Depends On | Purpose |
+|-----------|-----------|---------|
+| Geocoder | Nominatim API (public) | 좌표 → 주소 변환 |
+| LandCover | Overpass API (public) | 좌표 주변 토지이용 조회 |
+| Describer | Google AI Studio (Gemini) | 영상 자연어 설명 생성 |
+| Context Researcher | 웹 검색 API (TBD) | 시기별 지역 이벤트 조사 |
+| DB Client | Supabase (Service Key) | 설명 결과 저장/조회 |
+
+---
+
+## 3. Data Model
+
+### 3.1 API Request/Response
+
+```python
+# Request
+class DescribeRequest:
+    thumbnail: str          # base64 PNG 또는 URL (최하위 피라미드)
+    coordinates: list[float]  # [longitude, latitude]
+    bbox: list[float] | None  # [west, south, east, north] (optional)
+    captured_at: str        # ISO 8601 촬영일자
+
+# Response
+class DescribeResponse:
+    description: str        # Gemini 생성 자연어 설명문
+    location: Location
+    land_cover: LandCover
+    context: Context
+
+class Location:
+    country: str            # 국가명
+    country_code: str       # ISO 3166-1 alpha-2
+    region: str             # 광역 행정구역 (state/province)
+    city: str | None        # 도시/군/구
+    place_name: str         # display_name (전체 주소)
+    lat: float
+    lon: float
+
+class LandCover:
+    classes: list[LandCoverClass]  # 면적 비율 순 정렬
+    summary: str                   # "주거지역 45%, 농경지 30%, 산림 25%"
+
+class LandCoverClass:
+    type: str               # OSM landuse/natural tag 값 (residential, farmland, forest 등)
+    label: str              # 한국어 레이블
+    percentage: float | None  # bbox 내 추정 비율 (가능한 경우)
+
+class Context:
+    events: list[Event]     # 시기별 이벤트 (최대 5건)
+    summary: str            # 이벤트 요약문
+
+class Event:
+    title: str
+    date: str
+    source_url: str
+    relevance: str          # "high" | "medium" | "low"
+```
+
+### 3.2 DB Schema (신규 테이블)
+
+```sql
+-- 영상 설명 캐시 테이블
+CREATE TABLE public.image_descriptions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  cog_image_id UUID REFERENCES public.cog_images(id) ON DELETE CASCADE,
+  coordinates DOUBLE PRECISION[2] NOT NULL,  -- [lon, lat]
+  captured_at TIMESTAMPTZ,
+
+  -- Geocoding 결과
+  country TEXT,
+  country_code TEXT,
+  region TEXT,
+  city TEXT,
+  place_name TEXT,
+
+  -- 피복분류 결과
+  land_cover_json JSONB,     -- [{type, label, percentage}]
+  land_cover_summary TEXT,
+
+  -- Gemini 설명
+  description TEXT,
+
+  -- 맥락 조사 결과
+  context_json JSONB,        -- [{title, date, source_url, relevance}]
+  context_summary TEXT,
+
+  -- 메타
+  created_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT NOW() NOT NULL
+);
+
+-- 인덱스
+CREATE INDEX idx_image_desc_cog_id ON public.image_descriptions(cog_image_id);
+CREATE INDEX idx_image_desc_coords ON public.image_descriptions USING gist (
+  point(coordinates[1], coordinates[2])
+);
+```
+
+### 3.3 cog_images 테이블 확장
+
+```sql
+-- 기존 cog_images에 설명 서비스 연동 컬럼 추가
+ALTER TABLE public.cog_images
+  ADD COLUMN IF NOT EXISTS description_id UUID REFERENCES public.image_descriptions(id),
+  ADD COLUMN IF NOT EXISTS significance_score SMALLINT;  -- 0-100, v1.3에서 활용
+```
+
+---
+
+## 4. API Specification
+
+### 4.1 Endpoint List
+
+| Method | Path | Description | Auth |
+|--------|------|-------------|------|
+| POST | `/api/describe` | 영상 설명 생성 (전체) | API Key |
+| POST | `/api/geocode` | 역지오코딩만 | API Key |
+| POST | `/api/landcover` | 피복분류만 | API Key |
+| POST | `/api/context` | 맥락 조사만 | API Key |
+| GET | `/api/descriptions/{cog_image_id}` | 캐시된 설명 조회 | None |
+| GET | `/api/health` | 헬스체크 | None |
+
+### 4.2 Detailed Specification
+
+#### `POST /api/describe`
+
+통합 엔드포인트. 모든 모듈을 병렬 실행 후 조합하여 반환.
+
+**Request:**
+```json
+{
+  "thumbnail": "data:image/png;base64,iVBOR...",
+  "coordinates": [126.978, 37.566],
+  "bbox": [126.97, 37.56, 126.99, 37.57],
+  "captured_at": "2025-06-15T00:00:00Z",
+  "cog_image_id": "uuid-optional"
+}
+```
+
+**Response (200 OK):**
+```json
+{
+  "description": "서울특별시 중구 일대를 촬영한 위성영상입니다. 도심 중심부로 고층 건물과 도로망이 밀집되어 있으며, 남산과 녹지대가 확인됩니다.",
+  "location": {
+    "country": "대한민국",
+    "country_code": "KR",
+    "region": "서울특별시",
+    "city": "중구",
+    "place_name": "중구, 서울특별시, 대한민국",
+    "lat": 37.566,
+    "lon": 126.978
+  },
+  "land_cover": {
+    "classes": [
+      {"type": "commercial", "label": "상업지역", "percentage": 40},
+      {"type": "residential", "label": "주거지역", "percentage": 30},
+      {"type": "forest", "label": "산림", "percentage": 20},
+      {"type": "road", "label": "도로", "percentage": 10}
+    ],
+    "summary": "상업지역 40%, 주거지역 30%, 산림 20%, 도로 10%"
+  },
+  "context": {
+    "events": [
+      {
+        "title": "서울 도심 재개발 사업 본격화",
+        "date": "2025-06-10",
+        "source_url": "https://example.com/article",
+        "relevance": "medium"
+      }
+    ],
+    "summary": "2025년 6월 서울 중구 일대에서 도심 재개발 사업이 진행 중이었습니다."
+  },
+  "cached": false
+}
+```
+
+**Error Responses:**
+- `400`: 필수 필드 누락 또는 잘못된 좌표
+- `422`: 썸네일 디코딩 실패
+- `429`: Rate limit 초과
+- `500`: 내부 서버 오류
+- `503`: 외부 서비스 장애 (Nominatim, Overpass, Gemini)
+
+#### 점진적 실패 (Partial Response)
+
+개별 모듈 실패 시 해당 필드만 null로 반환하고 `warnings` 배열에 실패 사유 포함:
+
+```json
+{
+  "description": null,
+  "location": { "country": "대한민국", ... },
+  "land_cover": { ... },
+  "context": null,
+  "warnings": [
+    {"module": "describer", "error": "Gemini API timeout"},
+    {"module": "context", "error": "Web search rate limited"}
+  ],
+  "cached": false
+}
+```
+
+---
+
+## 5. Module Design
+
+### 5.1 Geocoder Module
+
+**외부 API**: [Nominatim Reverse Geocoding](https://nominatim.org/release-docs/latest/api/Reverse/)
+
+```
+GET https://nominatim.openstreetmap.org/reverse
+  ?lat=37.566&lon=126.978
+  &format=jsonv2
+  &accept-language=ko
+  &zoom=14
+```
+
+**사용 정책 준수:**
+- 1 request/sec 속도 제한
+- User-Agent 헤더 필수 (`COGnito/1.2`)
+- 결과 캐싱 (동일 좌표 ±0.001도 범위는 캐시 히트)
+
+**캐시 전략:**
+- 좌표를 소수점 3자리(~111m)로 반올림하여 캐시 키 생성
+- TTL: 30일 (지명은 자주 바뀌지 않음)
+
+### 5.2 LandCover Module
+
+**외부 API**: [Overpass API](https://wiki.openstreetmap.org/wiki/Overpass_API)
+
+```
+[out:json][timeout:10];
+(
+  way["landuse"](around:500, 37.566, 126.978);
+  way["natural"](around:500, 37.566, 126.978);
+  way["leisure"](around:500, 37.566, 126.978);
+  relation["landuse"](around:500, 37.566, 126.978);
+);
+out tags;
+```
+
+좌표 중심 반경 500m 내의 landuse/natural/leisure 태그를 조회하여 피복분류 구성.
+
+**OSM 태그 → 한국어 매핑 (주요):**
+
+| OSM tag | 한국어 |
+|---------|--------|
+| residential | 주거지역 |
+| commercial | 상업지역 |
+| industrial | 산업지역 |
+| farmland | 농경지 |
+| forest | 산림 |
+| grass/meadow | 초지 |
+| water | 수역 |
+| wetland | 습지 |
+| bare_rock | 나지 |
+| road (highway) | 도로 |
+
+**캐시 전략:**
+- 좌표를 소수점 2자리(~1.1km)로 반올림하여 캐시 키 생성
+- TTL: 90일 (토지이용은 느리게 변화)
+
+### 5.3 Describer Module (Gemini Vision)
+
+**외부 API**: [Google Gemini API](https://ai.google.dev/gemini-api/docs/image-understanding)
+
+```python
+import google.generativeai as genai
+
+genai.configure(api_key=os.environ["GOOGLE_AI_API_KEY"])
+model = genai.GenerativeModel("gemini-2.0-flash")
+
+response = model.generate_content([
+    image_data,  # 썸네일 이미지
+    f"""이 위성영상을 분석해주세요.
+위치: {place_name} ({country})
+촬영일자: {captured_at}
+피복분류: {land_cover_summary}
+
+다음을 포함하여 2-3문장으로 설명해주세요:
+1. 영상에서 관찰되는 주요 지형/지물
+2. 영상의 특이사항이나 주목할 점
+3. 이 영상이 흥미로운 이유
+
+한국어로 작성해주세요."""
+])
+```
+
+**비용 관리:**
+- Google AI Studio Pro 구독 범위 내 사용
+- gemini-2.0-flash 모델 (빠르고 저렴)
+- 배치 처리 시 분당 15 요청 제한
+- 캐시: cog_image_id 기준, TTL 없음 (영구 캐시)
+
+### 5.4 Context Researcher Module
+
+**외부 API**: 검토 필요 (DuckDuckGo Instant Answer / Google Custom Search / SerpAPI)
+
+```python
+query = f"{place_name} {captured_at[:7]}"  # "서울특별시 중구 2025-06"
+# → 웹 검색 → 상위 5개 결과에서 이벤트 추출
+```
+
+**초기 구현 (MVP):**
+- DuckDuckGo Instant Answer API (무료, 제한적)
+- 검색 결과에서 제목/날짜/URL만 추출
+- Gemini로 관련성 판단 (relevance scoring)
+
+**캐시 전략:**
+- 지역명 + 월 단위 캐시 키
+- TTL: 7일 (뉴스성 정보는 빠르게 변화)
+
+---
+
+## 6. Error Handling
+
+### 6.1 Error Response Format
+
+```json
+{
+  "error": {
+    "code": "GEOCODE_FAILED",
+    "message": "역지오코딩에 실패했습니다",
+    "details": {"service": "nominatim", "status": 503}
+  }
+}
+```
+
+### 6.2 Rate Limiting
+
+| Service | Limit | 대응 |
+|---------|-------|------|
+| Nominatim | 1 req/sec | asyncio.Semaphore + sleep |
+| Overpass | ~10,000 req/day | 캐시 적극 활용 |
+| Gemini (AI Studio Pro) | RPM 제한 | 배치 큐 + 재시도 |
+
+### 6.3 Circuit Breaker
+
+외부 서비스 연속 5회 실패 시 해당 모듈 30초간 비활성화 후 재시도.
+
+---
+
+## 7. Security Considerations
+
+- [x] API Key 인증 (COGnito 프론트엔드 ↔ Descriptor 서비스 간)
+- [x] 환경변수로 모든 시크릿 관리 (GOOGLE_AI_API_KEY, SUPABASE_SERVICE_KEY)
+- [x] Rate limiting (클라이언트당 10 req/min)
+- [x] 입력 검증 (좌표 범위 -180~180, -90~90)
+- [x] base64 이미지 크기 제한 (max 5MB)
+- [x] CORS 설정 (COGnito 도메인만 허용)
+
+---
+
+## 8. Test Plan
+
+### 8.1 Test Scope
+
+| Type | Target | Tool |
+|------|--------|------|
+| Unit Test | 각 모듈 (Geocoder, LandCover, Describer, Context) | pytest |
+| Integration Test | API 엔드포인트 | pytest + httpx |
+| E2E Test | 프론트엔드 → 서비스 → DB 저장 | Playwright |
+
+### 8.2 Test Cases
+
+- [ ] 서울 좌표 입력 → 역지오코딩 결과에 "대한민국", "서울" 포함
+- [ ] 해양 좌표 (태평양) 입력 → location은 반환, land_cover는 빈 배열
+- [ ] 잘못된 좌표 입력 → 400 에러
+- [ ] Nominatim 장애 시 → description/land_cover/context는 정상, location만 null + warning
+- [ ] 동일 좌표 2회 요청 → 2번째는 캐시에서 반환 (cached: true)
+- [ ] 대용량 이미지 (>5MB) → 422 에러
+
+---
+
+## 9. Project Structure
+
+### 9.1 File Structure
+
+```
+cognito-descriptor/              # 별도 레포지토리 또는 서브디렉토리
+├── pyproject.toml               # uv / poetry 프로젝트 설정
+├── Dockerfile
+├── .env.example
+├── README.md
+│
+├── app/
+│   ├── __init__.py
+│   ├── main.py                  # FastAPI app, 라우터 등록
+│   ├── config.py                # 환경변수, 설정
+│   │
+│   ├── api/
+│   │   ├── __init__.py
+│   │   ├── routes.py            # 엔드포인트 정의
+│   │   └── schemas.py           # Pydantic 모델 (Request/Response)
+│   │
+│   ├── modules/
+│   │   ├── __init__.py
+│   │   ├── geocoder.py          # Nominatim 역지오코딩
+│   │   ├── landcover.py         # Overpass 피복분류
+│   │   ├── describer.py         # Gemini Vision 영상설명
+│   │   └── context.py           # 웹 검색 맥락조사
+│   │
+│   ├── services/
+│   │   ├── __init__.py
+│   │   └── composer.py          # 모듈 오케스트레이션, 병렬 실행
+│   │
+│   ├── cache/
+│   │   ├── __init__.py
+│   │   └── store.py             # 캐시 레이어 (SQLite 기본)
+│   │
+│   └── db/
+│       ├── __init__.py
+│       └── supabase.py          # Supabase 클라이언트
+│
+└── tests/
+    ├── test_geocoder.py
+    ├── test_landcover.py
+    ├── test_describer.py
+    ├── test_context.py
+    ├── test_composer.py
+    └── test_api.py
+```
+
+### 9.2 Implementation Order
+
+1. [ ] 프로젝트 초기화 (FastAPI + pyproject.toml + Docker)
+2. [ ] Pydantic 스키마 정의 (Request/Response 모델)
+3. [ ] Geocoder 모듈 구현 (Nominatim + 캐시)
+4. [ ] LandCover 모듈 구현 (Overpass + OSM 태그 매핑 + 캐시)
+5. [ ] Describer 모듈 구현 (Gemini Vision + 프롬프트)
+6. [ ] Context Researcher 모듈 구현 (웹 검색 + 이벤트 추출)
+7. [ ] Composer 서비스 구현 (병렬 실행 + 점진적 실패)
+8. [ ] API 라우터 구현 (POST /api/describe 등)
+9. [ ] Supabase 연동 (image_descriptions 테이블 + 저장)
+10. [ ] 프론트엔드 연동 (catalogUI에서 설명 표시)
+11. [ ] 테스트 작성 및 검증
+12. [ ] Docker 배포 설정
+
+---
+
+## 10. Coding Conventions (Python)
+
+| Item | Convention |
+|------|-----------|
+| 패키지 관리 | uv (빠른 설치, lockfile 지원) |
+| 코드 포매터 | ruff format |
+| 린터 | ruff check |
+| 타입 힌트 | 모든 함수에 타입 힌트 적용 |
+| 비동기 | asyncio + httpx (비동기 HTTP 클라이언트) |
+| 환경변수 | pydantic-settings |
+| 로깅 | structlog (JSON 구조화 로깅) |
+
+---
+
+## 11. Environment Variables
+
+| Variable | Purpose | Required |
+|----------|---------|:--------:|
+| `GOOGLE_AI_API_KEY` | Gemini Vision API 키 | Yes |
+| `SUPABASE_URL` | Supabase 프로젝트 URL | Yes |
+| `SUPABASE_SERVICE_KEY` | Supabase 서비스 키 (서버 전용) | Yes |
+| `API_KEY` | COGnito → Descriptor 인증 키 | Yes |
+| `NOMINATIM_URL` | Nominatim 엔드포인트 (기본: public) | No |
+| `OVERPASS_URL` | Overpass 엔드포인트 (기본: public) | No |
+| `CACHE_DB_PATH` | SQLite 캐시 DB 경로 (기본: ./cache.db) | No |
+| `LOG_LEVEL` | 로그 레벨 (기본: INFO) | No |
+
+---
+
+## Version History
+
+| Version | Date | Changes | Author |
+|---------|------|---------|--------|
+| 0.1 | 2026-02-26 | Initial draft | conaonda |


### PR DESCRIPTION
## Summary
- v2-roadmap.plan.md: v1.1~v2.0 마일스톤 세분화 (뷰어 강화 → 영상 설명 → 큐레이션 → UI → 플랫폼 완성)
- image-descriptor.design.md: 독립 Python 백엔드 서비스 설계 (Nominatim, Overpass, Gemini Vision, 웹 검색)

## Test plan
- [ ] 문서 내용 검토 (마일스톤 범위, 기술 스택 결정)
- [ ] Design 문서의 API 스펙/데이터 모델 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)