### PR TITLE
fix: reposition viewer controls button closer to coordinate display (#98)

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,7 +179,7 @@
     /* 뷰어 컨트롤 패널 */
     .vc-toggle-btn {
       position: absolute;
-      bottom: 6rem;
+      bottom: 4.5rem;
       right: 1.5rem;
       z-index: 15;
       background: rgba(255,255,255,0.95);
@@ -192,7 +192,7 @@
     }
     .viewer-controls-panel {
       position: absolute;
-      bottom: 6rem;
+      bottom: 4.5rem;
       right: 1.5rem;
       z-index: 15;
       background: rgba(255,255,255,0.97);
@@ -323,6 +323,14 @@
 
       #coordinate-display {
         display: none !important;
+      }
+
+      .vc-toggle-btn {
+        bottom: 1.5rem;
+      }
+
+      .viewer-controls-panel {
+        bottom: 1.5rem;
       }
 
     }


### PR DESCRIPTION
## Summary
- ⚙ 버튼(`bottom:6rem`)이 좌표 표시와 너무 떨어져 맵 가운데 떠있는 느낌 → 좌표 표시 바로 위로 배치
- Desktop: `bottom: 6rem` → `4.5rem` (좌표 표시 바로 위 ~0.5rem 간격)
- Mobile(≤768px): `bottom: 1.5rem` (좌표 표시 hidden이므로 하단 배치)

## Test plan
- [ ] 데스크톱: ⚙ 버튼이 좌표 표시 바로 위에 위치하는지 확인
- [ ] 패널 열릴 때 좌표 표시와 겹치지 않는지 확인
- [ ] 모바일(≤768px): 버튼이 하단 우측에 적절히 위치하는지 확인

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)