### PR TITLE
fix: prevent image stretching at low zoom levels

### DIFF
--- a/src/cogLayer.js
+++ b/src/cogLayer.js
@@ -127,14 +127,15 @@ const applyAffineBypass = (cogSource, cogView, viewProjection, targetTileSize) =
       const cappedH = Math.min(uncappedH, MAX_SOURCE_TILE_DIM, coarsestH)
       extraSourceTileSizes.push([cappedW, cappedH])
 
-      // sourceTileSize가 cap되면 비정방이 될 수 있음.
-      // renderTileSize를 source 비율에 맞춰 조정하여 왜곡 방지.
-      if (cappedW === uncappedW && cappedH === uncappedH) {
+      const isCapped = cappedW < uncappedW || cappedH < uncappedH
+      if (!isCapped) {
         extraRenderTileSizes.push([baseTile[0], baseTile[1]])
       } else {
-        const maxDim = Math.max(cappedW, cappedH)
-        const renderW = Math.max(1, Math.round(baseTile[0] * cappedW / maxDim))
-        const renderH = Math.max(1, Math.round(baseTile[0] * cappedH / maxDim))
+        // cap된 레벨: 1개 타일이 정확히 extent를 덮도록 renderTileSize 역산.
+        // 해상도 r은 scaleX 기반이므로, extW/r과 extH/r을 직접 사용해야
+        // X/Y 스케일 차이(UTM→3857 등)로 인한 왜곡을 방지할 수 있음.
+        const renderW = Math.max(1, Math.ceil(extW / r))
+        const renderH = Math.max(1, Math.ceil(extH / r))
         extraRenderTileSizes.push([renderW, renderH])
       }
       if (r >= maxViewRes) break


### PR DESCRIPTION
## Summary
- 줌 아웃 시 extra 타일 레벨에서 비정방 overview가 정방 타일에 매핑되어 영상이 늘어나고 잘리는 문제 수정
- `renderTileSize`를 `sourceTileSize` 비율에 맞춰 조정하여 픽셀 왜곡 방지
- 기존 uncapped 레벨(정방)은 동작 변경 없음

## Root Cause
`applyAffineBypass`의 extra zoom levels에서:
- `sourceTileSize` = `[coarsestW, coarsestH]` (비정방, e.g. 200×120)
- `renderTileSize` = `[256, 256]` (항상 정방)
- 비정방 텍스처가 정방 지리 영역에 매핑 → 늘어남/잘림

## Test plan
- [ ] Harvey SkySat 영상 로드 후 줌 레벨 10 이하로 줌 아웃 → 영상 왜곡 없는지 확인
- [ ] 줌 레벨 10 이상에서 기존 렌더링 품질 유지되는지 확인
- [ ] 다른 COG 영상에서 줌 아웃 시 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)