### PR TITLE
ci: remove deleted cog-layer refs and add vitest to PR workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,9 +73,7 @@ jobs:
               - 'index.html'
               - 'vite.config.js'
             cog:
-              - 'src/cogLayer.js'
-              - 'src/cogImageLayer.js'
-              - 'src/AffineTileLayer.js'
+              - 'src/proxy.js'
             stac:
               - 'src/stac.js'
               - 'src/stacUI.js'
@@ -93,6 +91,7 @@ jobs:
               - '.github/workflows/**'
               - 'playwright.config.js'
               - 'playwright.auth.config.js'
+              - 'vitest.config.js'
 
       - run: npm ci
 
@@ -126,12 +125,6 @@ jobs:
       - name: Run all tests
         if: steps.changes.outputs.core == 'true' || steps.changes.outputs.ci == 'true'
         run: npx playwright test
-        env:
-          CI: true
-
-      - name: Run COG rendering tests only
-        if: steps.changes.outputs.core != 'true' && steps.changes.outputs.ci != 'true' && steps.changes.outputs.cog == 'true'
-        run: npx playwright test --project=cog-rendering
         env:
           CI: true
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -51,6 +51,11 @@ jobs:
           VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
           VITE_CORS_PROXY_URL: https://cog-cors-proxy.conaonda.workers.dev
 
+      - name: Run unit tests
+        run: npx vitest run
+        env:
+          CI: true
+
       - run: npx playwright test
         env:
           CI: true


### PR DESCRIPTION
## Summary
- `deploy.yml`: paths-filter `cog` 그룹을 삭제된 파일(cogLayer, cogImageLayer, AffineTileLayer) → `src/proxy.js`로 대체
- `deploy.yml`: `ci` 필터에 `vitest.config.js` 추가
- `deploy.yml`: 삭제된 `cog-rendering` Playwright 프로젝트 참조 스텝 제거
- `playwright.yml`: Playwright 실행 전 `npx vitest run` 스텝 추가

## Test plan
- [ ] YAML 문법 검증 완료
- [ ] 삭제된 파일/프로젝트 참조 없음 확인 (`grep -r` 검증)
- [ ] CI 워크플로 정상 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)