### PR TITLE
feat: 밴드별 독립 Min/Max 스트레치 슬라이더

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,6 +243,14 @@
       gap: 0.3rem;
     }
     .vc-slider-row span { font-size: 0.65rem; color: #666; min-width: 3rem; text-align: right; }
+    .vc-stretch-mode { display: flex; gap: 0.5rem; margin-bottom: 0.3rem; }
+    .vc-stretch-mode label { font-size: 0.65rem; color: #666; cursor: pointer; display: flex; align-items: center; gap: 0.2rem; }
+    .vc-stretch-mode input[type="radio"] { margin: 0; }
+    .vc-perband-channel { margin-bottom: 0.4rem; padding-left: 0.2rem; border-left: 2px solid #ddd; }
+    .vc-perband-channel[data-channel="R"] { border-left-color: #e74c3c; }
+    .vc-perband-channel[data-channel="G"] { border-left-color: #27ae60; }
+    .vc-perband-channel[data-channel="B"] { border-left-color: #3498db; }
+    .vc-channel-label { font-size: 0.6rem; font-weight: 600; color: #666; }
     .vc-btn-group { display: flex; gap: 0.3rem; }
     .vc-btn-group button {
       flex: 1;
@@ -1360,15 +1368,62 @@
       <button id="vc-toggle-btn-close" class="vc-toggle-btn" aria-label="뷰어 컨트롤 닫기">&times;</button>
       <div class="vc-section">
         <span class="vc-label">Min / Max 스트레치</span>
-        <div class="vc-slider-row">
-          <span>Min</span>
-          <input type="range" id="vc-min-slider" min="0" max="1" step="0.1" value="0" aria-label="최소값 스트레치">
-          <span id="vc-min-value">0</span>
+        <div class="vc-stretch-mode">
+          <label><input type="radio" name="vc-stretch-mode" value="batch" checked> 일괄</label>
+          <label><input type="radio" name="vc-stretch-mode" value="perband"> 개별</label>
         </div>
-        <div class="vc-slider-row">
-          <span>Max</span>
-          <input type="range" id="vc-max-slider" min="0" max="1" step="0.1" value="1" aria-label="최대값 스트레치">
-          <span id="vc-max-value">1</span>
+        <div id="vc-stretch-batch">
+          <div class="vc-slider-row">
+            <span>Min</span>
+            <input type="range" id="vc-min-slider" min="0" max="1" step="0.1" value="0" aria-label="최소값 스트레치">
+            <span id="vc-min-value">0</span>
+          </div>
+          <div class="vc-slider-row">
+            <span>Max</span>
+            <input type="range" id="vc-max-slider" min="0" max="1" step="0.1" value="1" aria-label="최대값 스트레치">
+            <span id="vc-max-value">1</span>
+          </div>
+        </div>
+        <div id="vc-stretch-perband" style="display:none">
+          <div class="vc-perband-channel" data-channel="R">
+            <span class="vc-channel-label">R</span>
+            <div class="vc-slider-row">
+              <span>Min</span>
+              <input type="range" class="vc-perband-min" min="0" max="1" step="0.1" value="0" aria-label="R 최소값">
+              <span class="vc-perband-min-value">0</span>
+            </div>
+            <div class="vc-slider-row">
+              <span>Max</span>
+              <input type="range" class="vc-perband-max" min="0" max="1" step="0.1" value="1" aria-label="R 최대값">
+              <span class="vc-perband-max-value">1</span>
+            </div>
+          </div>
+          <div class="vc-perband-channel" data-channel="G">
+            <span class="vc-channel-label">G</span>
+            <div class="vc-slider-row">
+              <span>Min</span>
+              <input type="range" class="vc-perband-min" min="0" max="1" step="0.1" value="0" aria-label="G 최소값">
+              <span class="vc-perband-min-value">0</span>
+            </div>
+            <div class="vc-slider-row">
+              <span>Max</span>
+              <input type="range" class="vc-perband-max" min="0" max="1" step="0.1" value="1" aria-label="G 최대값">
+              <span class="vc-perband-max-value">1</span>
+            </div>
+          </div>
+          <div class="vc-perband-channel" data-channel="B">
+            <span class="vc-channel-label">B</span>
+            <div class="vc-slider-row">
+              <span>Min</span>
+              <input type="range" class="vc-perband-min" min="0" max="1" step="0.1" value="0" aria-label="B 최소값">
+              <span class="vc-perband-min-value">0</span>
+            </div>
+            <div class="vc-slider-row">
+              <span>Max</span>
+              <input type="range" class="vc-perband-max" min="0" max="1" step="0.1" value="1" aria-label="B 최대값">
+              <span class="vc-perband-max-value">1</span>
+            </div>
+          </div>
         </div>
         <button id="vc-reset-btn" aria-label="Min/Max 자동 설정">자동</button>
       </div>

--- a/src/main.js
+++ b/src/main.js
@@ -290,9 +290,7 @@ const loadCOG = async (rawUrl, catalogMeta = null, overrideBandInfo = null) => {
       if (!state || !currentCogLayer) return
 
       const newBandInfo = { type: style.bandType, bands: style.bands }
-      const newStats = style.bandType === 'rgb'
-        ? state.stats.map(() => ({ min: style.min, max: style.max }))
-        : [{ min: style.min, max: style.max }]
+      const newStats = style.stats
 
       const bandsChanged = JSON.stringify(style.bands) !== JSON.stringify(state.bandInfo.bands)
 

--- a/src/viewerControls.js
+++ b/src/viewerControls.js
@@ -15,7 +15,7 @@ export function initViewerControls(onStyleChange, onProjectionChange) {
   const panel = document.getElementById('viewer-controls-panel')
   if (!panel) return
 
-  // Min/Max 슬라이더 이벤트
+  // Min/Max 슬라이더 이벤트 (일괄)
   const minSlider = document.getElementById('vc-min-slider')
   const maxSlider = document.getElementById('vc-max-slider')
   const minVal = document.getElementById('vc-min-value')
@@ -34,13 +34,35 @@ export function initViewerControls(onStyleChange, onProjectionChange) {
       emitStyleChange()
     })
   }
+
+  // 밴드별 슬라이더 이벤트 (개별)
+  const perbandChannels = document.querySelectorAll('.vc-perband-channel')
+  perbandChannels.forEach(ch => {
+    const pMin = ch.querySelector('.vc-perband-min')
+    const pMax = ch.querySelector('.vc-perband-max')
+    const pMinVal = ch.querySelector('.vc-perband-min-value')
+    const pMaxVal = ch.querySelector('.vc-perband-max-value')
+    if (pMin) pMin.addEventListener('input', () => { pMinVal.textContent = Number(pMin.value).toFixed(1); emitStyleChange() })
+    if (pMax) pMax.addEventListener('input', () => { pMaxVal.textContent = Number(pMax.value).toFixed(1); emitStyleChange() })
+  })
+
+  // 스트레치 모드 토글 (일괄/개별)
+  const stretchModeRadios = document.querySelectorAll('input[name="vc-stretch-mode"]')
+  const batchGroup = document.getElementById('vc-stretch-batch')
+  const perbandGroup = document.getElementById('vc-stretch-perband')
+  stretchModeRadios.forEach(radio => {
+    radio.addEventListener('change', () => {
+      const isPerband = radio.value === 'perband' && radio.checked
+      if (batchGroup) batchGroup.style.display = isPerband ? 'none' : ''
+      if (perbandGroup) perbandGroup.style.display = isPerband ? '' : 'none'
+      emitStyleChange()
+    })
+  })
+
   if (resetBtn) {
     resetBtn.addEventListener('click', () => {
       if (!currentStats) return
-      minSlider.value = currentStats[0].min
-      maxSlider.value = currentStats[0].max
-      minVal.textContent = currentStats[0].min.toFixed(1)
-      maxVal.textContent = currentStats[0].max.toFixed(1)
+      resetSlidersToStats(currentStats)
       emitStyleChange()
     })
   }
@@ -123,6 +145,27 @@ export function updateControlsForCog(totalBands, bandInfo, stats, projectionMode
     minVal.textContent = s.min.toFixed(1)
     maxVal.textContent = s.max.toFixed(1)
   }
+
+  // 밴드별 슬라이더 초기화
+  const perbandChannels = document.querySelectorAll('.vc-perband-channel')
+  perbandChannels.forEach((ch, i) => {
+    const s = stats[i] || stats[0]
+    const pMin = ch.querySelector('.vc-perband-min')
+    const pMax = ch.querySelector('.vc-perband-max')
+    const pMinVal = ch.querySelector('.vc-perband-min-value')
+    const pMaxVal = ch.querySelector('.vc-perband-max-value')
+    if (pMin) {
+      pMin.min = s.min; pMin.max = s.max; pMin.step = (s.max - s.min) / 200; pMin.value = s.min
+      pMinVal.textContent = s.min.toFixed(1)
+    }
+    if (pMax) {
+      pMax.min = s.min; pMax.max = s.max; pMax.step = (s.max - s.min) / 200; pMax.value = s.max
+      pMaxVal.textContent = s.max.toFixed(1)
+    }
+  })
+
+  // 스트레치 모드: RGB일 때만 개별 선택 가능
+  updateStretchModeVisibility(bandInfo.type)
 
   // 밴드 드롭다운 옵션 생성
   populateBandOptions(totalBands, bandInfo)
@@ -219,12 +262,70 @@ export function getCurrentStyle() {
     bands = [Number(document.getElementById('vc-band-single')?.value || 1)]
   }
 
+  const stretchMode = document.querySelector('input[name="vc-stretch-mode"]:checked')
+  const isPerband = isRgb && stretchMode?.value === 'perband'
+
+  let stats
+  if (isPerband) {
+    const channels = document.querySelectorAll('.vc-perband-channel')
+    stats = Array.from(channels).map(ch => ({
+      min: Number(ch.querySelector('.vc-perband-min')?.value || 0),
+      max: Number(ch.querySelector('.vc-perband-max')?.value || 1)
+    }))
+  } else {
+    const min = Number(minSlider?.value || 0)
+    const max = Number(maxSlider?.value || 1)
+    stats = isRgb ? [{ min, max }, { min, max }, { min, max }] : [{ min, max }]
+  }
+
   return {
     bands,
     bandType: isRgb ? 'rgb' : 'gray',
     colormap: colormapSelect?.value || 'grayscale',
-    min: Number(minSlider?.value || 0),
-    max: Number(maxSlider?.value || 1)
+    min: stats[0].min,
+    max: stats[0].max,
+    stats
+  }
+}
+
+function resetSlidersToStats(stats) {
+  const minSlider = document.getElementById('vc-min-slider')
+  const maxSlider = document.getElementById('vc-max-slider')
+  const minVal = document.getElementById('vc-min-value')
+  const maxVal = document.getElementById('vc-max-value')
+
+  if (minSlider && stats.length > 0) {
+    minSlider.value = stats[0].min
+    maxSlider.value = stats[0].max
+    minVal.textContent = stats[0].min.toFixed(1)
+    maxVal.textContent = stats[0].max.toFixed(1)
+  }
+
+  const channels = document.querySelectorAll('.vc-perband-channel')
+  channels.forEach((ch, i) => {
+    const s = stats[i] || stats[0]
+    const pMin = ch.querySelector('.vc-perband-min')
+    const pMax = ch.querySelector('.vc-perband-max')
+    if (pMin) { pMin.value = s.min; ch.querySelector('.vc-perband-min-value').textContent = s.min.toFixed(1) }
+    if (pMax) { pMax.value = s.max; ch.querySelector('.vc-perband-max-value').textContent = s.max.toFixed(1) }
+  })
+}
+
+function updateStretchModeVisibility(bandType) {
+  const stretchModeDiv = document.querySelector('.vc-stretch-mode')
+  if (stretchModeDiv) {
+    stretchModeDiv.style.display = bandType === 'rgb' ? 'flex' : 'none'
+  }
+  // 단일밴드면 일괄 모드로 강제 전환
+  if (bandType !== 'rgb') {
+    const batchRadio = document.querySelector('input[name="vc-stretch-mode"][value="batch"]')
+    if (batchRadio) {
+      batchRadio.checked = true
+      const batchGroup = document.getElementById('vc-stretch-batch')
+      const perbandGroup = document.getElementById('vc-stretch-perband')
+      if (batchGroup) batchGroup.style.display = ''
+      if (perbandGroup) perbandGroup.style.display = 'none'
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- RGB 모드에서 일괄/개별 스트레치 모드 전환 지원 (라디오 버튼)
- 밴드별(R/G/B) 독립 min/max 슬라이더 UI 추가 (채널별 컬러 인디케이터)
- `getCurrentStyle()`이 밴드별 `stats` 배열을 반환하여 렌더링 파이프라인에 직접 전달

## Test plan
- [ ] COG 로드 → 일괄 모드에서 Min/Max 슬라이더 조절 → 영상 밝기/대비 실시간 변경 확인
- [ ] RGB 모드에서 "개별" 선택 → R/G/B 채널별 독립 조절 확인
- [ ] 단일밴드 모드 전환 시 개별 옵션 숨김 확인
- [ ] "자동" 버튼 클릭 → 일괄/개별 슬라이더 모두 원래 통계값으로 리셋 확인
- [ ] 극단값(min ≈ max) 입력 시 렌더링 안정성 확인

closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)