### PR TITLE
perf: 코드 스플리팅으로 초기 번들 51% 감소

### DIFF
--- a/sprint-logs/bundle-analysis.md
+++ b/sprint-logs/bundle-analysis.md
@@ -1,0 +1,49 @@
+# 번들 분석 보고서
+
+## 측정일: 2026-03-06
+
+### 최적화 전 (기준선)
+
+| 청크 | 크기 | gzip |
+|------|------|------|
+| index.js | 724 kB | 236 kB |
+| vendor.js (OL) | 292 kB | 84 kB |
+| **초기 로드 합계** | **1,016 kB** | **320 kB** |
+
+### 최적화 후
+
+| 청크 | 크기 | gzip | 로드 시점 |
+|------|------|------|----------|
+| index.js (앱 코어) | 207 kB | 59 kB | 즉시 |
+| vendor.js (OL) | 292 kB | 84 kB | 즉시 |
+| ol-mapbox-style 청크 | 484 kB | 168 kB | 비동기 |
+| stacUI 청크 | 24 kB | 8 kB | 비동기 |
+| registerUI 청크 | 7.5 kB | 3 kB | 비동기 |
+| catalog 청크 | 3 kB | 2 kB | 비동기 |
+| **초기 로드 합계** | **499 kB** | **143 kB** |
+
+### 개선 효과
+
+- 초기 로드 JS: 1,016 kB → **499 kB** (**51% 감소**)
+- 초기 gzip: 320 kB → **143 kB** (**55% 감소**)
+- Vite 500 kB 경고 해소 (index.js 207 kB)
+
+### 주요 변경사항
+
+1. **`ol-mapbox-style` 동적 import**: 베이스맵 스타일 라이브러리를 비동기 로드로 전환. 484 kB를 초기 로드에서 제거.
+2. **UI 모듈 코드 스플리팅**: authUI, catalogUI, stacUI, watchlistUI, registerUI를 동적 import로 전환. 초기 렌더링에 불필요한 코드 지연 로드.
+3. **`consumePreLoginState` 인라인**: auth.js 의존성 제거로 supabase 모듈 체인 분리.
+
+### 참고사항
+
+- `@supabase/supabase-js`: 환경변수(`VITE_SUPABASE_URL`) 미설정 시 트리쉐이킹으로 완전 제거됨. 프로덕션 배포 시 환경변수 설정 후 재측정 필요.
+- OpenLayers: 이미 ESM 트리쉐이킹 적용됨. vendor 292 kB는 실제 사용 모듈만 포함.
+- `@conaonda/ol-cog-layers` + geotiff: 핵심 COG 렌더링 로직으로 분리 불가.
+
+### 향후 개선 가능 항목
+
+| 항목 | 예상 효과 | 난이도 |
+|------|----------|--------|
+| geotiff decoder lazy loading | ~100 kB 절감 | 높음 (라이브러리 수정 필요) |
+| Lighthouse CI 자동 측정 | 성능 회귀 감지 | 중간 |
+| HTTP/2 서버 푸시 설정 | 체감 로딩 속도 개선 | 낮음 |

--- a/src/main.js
+++ b/src/main.js
@@ -1,18 +1,10 @@
 import { Map, View } from 'ol'
 import LayerGroup from 'ol/layer/Group'
-import { apply } from 'ol-mapbox-style'
 import { defaults as defaultControls } from 'ol/control'
 import { transform } from 'ol/proj'
 import { createCOGLayer, buildStyle, getTotalBands, getMinMaxFromOverview, createCOGSource, buildStyleWithColormap } from '@conaonda/ol-cog-layers'
 import { createCOGImageLayer } from '@conaonda/ol-cog-layers'
-import { extractCogMetadata } from './catalog.js'
-import { initAuthUI } from './authUI.js'
-import { consumePreLoginState } from './auth.js'
 import { proxyCogUrl } from './proxy.js'
-import { initRegisterUI, openRegisterModalWithMeta } from './registerUI.js'
-import { initCatalogUI } from './catalogUI.js'
-import { initStacUI } from './stacUI.js'
-import { initWatchlistUI } from './watchlistUI.js'
 import { updateViewerMeta } from './viewerMeta.js'
 import { initViewerControls, updateControlsForCog, getCurrentStyle } from './viewerControls.js'
 import './colormaps.js'
@@ -26,7 +18,14 @@ if ('serviceWorker' in navigator) {
 
 const DEFAULT_COG_URL = 'https://storage.googleapis.com/pdd-stac/disasters/hurricane-harvey/0831/SkySat_20170831T195552Z_RGB.tif'
 
-const preLoginState = consumePreLoginState()
+// consumePreLoginState 인라인 (auth.js의 supabase 의존성 지연 로드를 위해)
+const PRE_LOGIN_STATE_KEY = 'cognito-pre-login-state'
+const preLoginState = (() => {
+  const raw = sessionStorage.getItem(PRE_LOGIN_STATE_KEY)
+  if (!raw) return null
+  sessionStorage.removeItem(PRE_LOGIN_STATE_KEY)
+  try { return JSON.parse(raw) } catch { return null }
+})()
 
 const urlParams = new URLSearchParams(window.location.search)
 const COG_URL = urlParams.get('url') || preLoginState?.cogUrl || DEFAULT_COG_URL
@@ -55,7 +54,7 @@ const showError = (message) => {
 }
 
 const initMap = async () => {
-  initAuthUI()
+  import('./authUI.js').then(m => m.initAuthUI())
   const viewProjection = 'EPSG:3857'
   let currentCogLayer = null
 
@@ -83,7 +82,7 @@ const initMap = async () => {
     })
   })
 
-  apply(baseGroup, './style.json')
+  import('ol-mapbox-style').then(m => m.apply(baseGroup, './style.json'))
 
   const coordDisplay = document.createElement('div')
   coordDisplay.id = 'coordinate-display'
@@ -232,6 +231,7 @@ const loadCOG = async (rawUrl, catalogMeta = null, overrideBandInfo = null) => {
 
       // 메타데이터 추출 및 저장
       try {
+        const { extractCogMetadata } = await import('./catalog.js')
         const cogMeta = await extractCogMetadata(tiff, rawUrl)
         if (thisLoad !== _loadVersion) return
         cogMeta.url = rawUrl
@@ -398,7 +398,7 @@ const loadCOG = async (rawUrl, catalogMeta = null, overrideBandInfo = null) => {
     loadCOG(urlInput.value.trim() || COG_URL)
   })
 
-  initRegisterUI()
+  import('./registerUI.js').then(m => m.initRegisterUI())
 
   // 패널 토글
   const vcToggleBtn = document.getElementById('vc-toggle-btn')
@@ -411,17 +411,17 @@ const loadCOG = async (rawUrl, catalogMeta = null, overrideBandInfo = null) => {
     vcCloseBtn.addEventListener('click', () => vcPanel.classList.remove('open'))
   }
 
-  initCatalogUI((url, catalogItem) => loadCOG(url, catalogItem))
-  initWatchlistUI((url, catalogItem) => loadCOG(url, catalogItem))
+  import('./catalogUI.js').then(m => m.initCatalogUI((url, catalogItem) => loadCOG(url, catalogItem)))
+  import('./watchlistUI.js').then(m => m.initWatchlistUI((url, catalogItem) => loadCOG(url, catalogItem)))
 
   // STAC UI 초기화
-  initStacUI(
+  import('./stacUI.js').then(m => m.initStacUI(
     (url) => loadCOG(url),
-    (stacMeta) => {
+    async (stacMeta) => {
       if (stacMeta.cogUrl) {
-        loadCOG(stacMeta.cogUrl).then(() => {
-          openRegisterModalWithMeta(stacMeta)
-        })
+        await loadCOG(stacMeta.cogUrl)
+        const { openRegisterModalWithMeta } = await import('./registerUI.js')
+        openRegisterModalWithMeta(stacMeta)
       }
     },
     () => {
@@ -431,7 +431,7 @@ const loadCOG = async (rawUrl, catalogMeta = null, overrideBandInfo = null) => {
       return [bl[0], bl[1], tr[0], tr[1]]
     },
     map
-  )
+  ))
 
   console.log('Map initialized successfully')
   window.olMap = map


### PR DESCRIPTION
## Summary
- `ol-mapbox-style` 동적 import로 484 kB를 비동기 로드로 전환
- UI 모듈(auth, catalog, stac, watchlist, register) 코드 스플리팅
- 초기 로드 JS: 1,016 kB → **499 kB** (51% 감소, gzip 기준 55% 감소)
- 번들 분석 보고서 추가 (`sprint-logs/bundle-analysis.md`)

## Test plan
- [x] `npx vitest run` — 95개 테스트 전체 통과
- [x] `npx vite build` — 빌드 성공, index 207 kB (500 kB 경고 해소)
- [ ] 베이스맵 정상 로드 확인 (ol-mapbox-style 비동기 로드)
- [ ] STAC/카탈로그/인증 UI 정상 동작 확인

closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)