### PR TITLE
chore: PRE_LOGIN_STATE_KEY 문자열 중복 해소

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -1,4 +1,5 @@
 import { supabase } from './supabase.js'
+import { PRE_LOGIN_STATE_KEY } from './constants.js'
 
 /**
  * OAuth 로그인
@@ -48,7 +49,6 @@ export async function signUpWithEmail(email, password) {
   })
 }
 
-const STATE_KEY = 'cognito-pre-login-state'
 
 function savePreLoginState() {
   const state = {}
@@ -58,16 +58,16 @@ function savePreLoginState() {
     state.center = view.getCenter()
     state.zoom = view.getZoom()
   }
-  sessionStorage.setItem(STATE_KEY, JSON.stringify(state))
+  sessionStorage.setItem(PRE_LOGIN_STATE_KEY, JSON.stringify(state))
 }
 
 /**
  * 로그인 전 저장된 앱 상태 복원 (1회성)
  */
 export function consumePreLoginState() {
-  const raw = sessionStorage.getItem(STATE_KEY)
+  const raw = sessionStorage.getItem(PRE_LOGIN_STATE_KEY)
   if (!raw) return null
-  sessionStorage.removeItem(STATE_KEY)
+  sessionStorage.removeItem(PRE_LOGIN_STATE_KEY)
   try { return JSON.parse(raw) } catch { return null }
 }
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,1 @@
+export const PRE_LOGIN_STATE_KEY = 'cognito-pre-login-state'

--- a/src/main.js
+++ b/src/main.js
@@ -19,7 +19,7 @@ if ('serviceWorker' in navigator) {
 const DEFAULT_COG_URL = 'https://storage.googleapis.com/pdd-stac/disasters/hurricane-harvey/0831/SkySat_20170831T195552Z_RGB.tif'
 
 // consumePreLoginState 인라인 (auth.js의 supabase 의존성 지연 로드를 위해)
-const PRE_LOGIN_STATE_KEY = 'cognito-pre-login-state'
+import { PRE_LOGIN_STATE_KEY } from './constants.js'
 const preLoginState = (() => {
   const raw = sessionStorage.getItem(PRE_LOGIN_STATE_KEY)
   if (!raw) return null


### PR DESCRIPTION
## Summary
- `auth.js`의 `STATE_KEY`와 `main.js`의 `PRE_LOGIN_STATE_KEY` 중복 정의를 `src/constants.js`로 추출
- 양쪽 모두 `constants.js`에서 import하도록 변경

## Test plan
- [x] 기존 테스트 101개 모두 통과 (auth 테스트 포함)

closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)