### PR TITLE
fix: PWA 설치 프롬프트 취소 시 배너 재표시 방지

### DIFF
--- a/src/installPrompt.js
+++ b/src/installPrompt.js
@@ -27,9 +27,12 @@ window.addEventListener('beforeinstallprompt', (e) => {
   document.getElementById('install-btn').addEventListener('click', async () => {
     if (!deferredPrompt) return
     deferredPrompt.prompt()
-    await deferredPrompt.userChoice
+    const { outcome } = await deferredPrompt.userChoice
     deferredPrompt = null
     banner.classList.remove('active')
+    if (outcome === 'dismissed') {
+      sessionStorage.setItem(DISMISS_KEY, '1')
+    }
   })
 
   document.getElementById('install-dismiss').addEventListener('click', () => {

--- a/tests/unit/installPrompt.test.js
+++ b/tests/unit/installPrompt.test.js
@@ -52,6 +52,21 @@ describe('installPrompt.js', () => {
     expect(sessionStorage.getItem('cognito-install-dismissed')).toBe('1')
   })
 
+  it('네이티브 프롬프트 취소 시 sessionStorage에 dismiss 저장', async () => {
+    await loadInstallPrompt()
+
+    const mockEvent = {
+      preventDefault: vi.fn(),
+      prompt: vi.fn(),
+      userChoice: Promise.resolve({ outcome: 'dismissed' }),
+    }
+    window.dispatchEvent(Object.assign(new Event('beforeinstallprompt'), mockEvent))
+
+    document.getElementById('install-btn').click()
+    await mockEvent.userChoice
+    expect(sessionStorage.getItem('cognito-install-dismissed')).toBe('1')
+  })
+
   it('설치 버튼 클릭 시 prompt() 호출됨', async () => {
     await loadInstallPrompt()
 


### PR DESCRIPTION
## Summary
- 네이티브 설치 프롬프트에서 사용자가 취소(`dismissed`)한 경우에도 `sessionStorage`에 dismiss 상태를 저장
- 페이지 재로드 시 배너가 재표시되는 버그 수정
- 관련 유닛 테스트 추가

## Test plan
- [x] 기존 유닛 테스트 5개 통과
- [ ] 수동 테스트: 설치 프롬프트 취소 후 페이지 재로드 시 배너 미표시 확인

closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)