### PR TITLE
feat: Service Worker 타일 캐싱 고도화

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -9,7 +9,7 @@ self.addEventListener('activate', (e) => {
     caches.keys().then((keys) =>
       Promise.all(
         keys
-          .filter((k) => k.startsWith('cog-tile-') && k !== CACHE_NAME)
+          .filter((k) => (k.startsWith('cog-tile-') || k.startsWith('cog-range-')) && k !== CACHE_NAME)
           .map((k) => caches.delete(k))
       )
     ).then(() => self.clients.claim())

--- a/tests/unit/sw.test.js
+++ b/tests/unit/sw.test.js
@@ -205,5 +205,21 @@ describe('sw.js 로직', () => {
       expect(globalThis.caches.delete).not.toHaveBeenCalledWith('cog-tile-v1')
       expect(globalThis.caches.delete).not.toHaveBeenCalledWith('other-cache')
     })
+
+    it('이전 이름(cog-range-v*)의 캐시도 삭제함', async () => {
+      globalThis.caches.keys.mockResolvedValue(['cog-range-v1', 'cog-tile-v0', 'cog-tile-v1', 'other-cache'])
+      await loadSW()
+
+      const event = {
+        waitUntil: vi.fn((p) => p),
+      }
+      listeners.activate(event)
+      await event.waitUntil.mock.calls[0][0]
+
+      expect(globalThis.caches.delete).toHaveBeenCalledWith('cog-range-v1')
+      expect(globalThis.caches.delete).toHaveBeenCalledWith('cog-tile-v0')
+      expect(globalThis.caches.delete).not.toHaveBeenCalledWith('cog-tile-v1')
+      expect(globalThis.caches.delete).not.toHaveBeenCalledWith('other-cache')
+    })
   })
 })


### PR DESCRIPTION
## Summary
- 206 Partial Response를 200으로 래핑하여 Cache API에 저장 (기존 캐시 미스 문제 해결)
- cross-origin COG 요청도 캐싱 대상에 포함
- 최대 200개 항목 제한 및 FIFO 기반 자동 정리 (용량 관리)
- 이전 버전 캐시 자동 삭제 (activate 이벤트)

## Test plan
- [x] SW 유닛 테스트 8개 추가 및 통과
- [x] 기존 137개 테스트 전체 통과
- [ ] 동일 타일 재요청 시 캐시 히트 확인 (DevTools Network)
- [ ] 오프라인 상태에서 캐싱된 타일 표시 확인

closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)