### PR TITLE
fix: E2E 테스트 flaky 수정 (window.olMap 타이밍)

### DIFF
--- a/tests/auth/auth-ui.spec.js
+++ b/tests/auth/auth-ui.spec.js
@@ -67,9 +67,8 @@ test.describe('인증 UI 검증', () => {
       return loadingEl && !loadingEl.classList.contains('active')
     }, { timeout: 30000 })
 
-    // 지도가 초기화되었는지 확인
-    const mapExists = await page.evaluate(() => !!window.olMap)
-    expect(mapExists).toBe(true)
+    // 지도가 초기화되었는지 확인 (CI 환경에서 타이밍 이슈 방지)
+    await page.waitForFunction(() => !!window.olMap, { timeout: 30000 })
 
     // 에러가 표시되지 않는지 확인
     const errorEl = page.locator('#error')


### PR DESCRIPTION
## Summary
- `auth-ui.spec.js`에서 `window.olMap` 존재 여부를 즉시 평가(`page.evaluate`)하던 코드를 `waitForFunction` 폴링 방식으로 변경
- CI 환경에서 지도 초기화 지연으로 인한 간헐적 실패 해결

closes #149

## Test plan
- [x] `npx playwright test --config=playwright.auth.config.js` 로컬 통과 확인
- [ ] CI 파이프라인에서 3회 이상 연속 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)