### PR TITLE
feat: 밴드 선택 URL 파라미터 공유/복원

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -37,6 +37,7 @@ const RENDER_PIPELINE = urlParams.get('render') || 'tile'    // 'tile' | 'image'
 const TARGET_TILE_SIZE = parseInt(urlParams.get('tileSize'), 10) || 256
 const SHARED_CENTER = urlParams.get('center')  // 'lon,lat'
 const SHARED_ZOOM = urlParams.get('zoom')
+const SHARED_BANDS = urlParams.get('bands')  // '1,2,3' (RGB) or '4' (single)
 
 const MOBILE_MAX_ZOOM = 16
 const DEFAULT_MAX_ZOOM = 20
@@ -327,8 +328,14 @@ const loadCOG = async (rawUrl, catalogMeta = null, overrideBandInfo = null, { sk
     }
   )
 
-  // 초기 COG 로드
-  await loadCOG(COG_URL)
+  // 초기 COG 로드 (URL 밴드 파라미터 적용)
+  const initialBandInfo = (() => {
+    if (!SHARED_BANDS) return null
+    const bands = SHARED_BANDS.split(',').map(Number)
+    if (bands.some(b => !Number.isInteger(b) || b < 1)) return null
+    return { type: bands.length >= 3 ? 'rgb' : 'gray', bands }
+  })()
+  await loadCOG(COG_URL, null, initialBandInfo)
 
   // 공유 URL의 center/zoom 복원
   if (SHARED_CENTER && SHARED_ZOOM) {
@@ -367,6 +374,8 @@ const loadCOG = async (rawUrl, catalogMeta = null, overrideBandInfo = null, { sk
     params.set('url', cogUrl)
     params.set('center', `${lonLat[0].toFixed(6)},${lonLat[1].toFixed(6)}`)
     params.set('zoom', zoom.toFixed(1))
+    const activeBands = window._currentViewerState?.bandInfo?.bands
+    if (activeBands) params.set('bands', activeBands.join(','))
     const shareUrl = `${window.location.origin}${window.location.pathname}?${params}`
     navigator.clipboard.writeText(shareUrl).then(() => {
       const btn = document.getElementById('cog-share-btn')

--- a/tests/viewer/viewer-controls.spec.js
+++ b/tests/viewer/viewer-controls.spec.js
@@ -163,6 +163,54 @@ test.describe('Min/Max 스트레치 슬라이더', () => {
   })
 })
 
+test.describe('밴드 URL 파라미터 공유/복원', () => {
+
+  test('공유 URL에 bands 파라미터가 포함됨', async ({ page }) => {
+    await page.goto('')
+    await waitForCogReady(page)
+
+    // clipboardData를 캡처하기 위해 clipboard API를 모킹
+    let copiedUrl = ''
+    await page.evaluate(() => {
+      navigator.clipboard.writeText = async (text) => { window._copiedUrl = text }
+    })
+
+    await page.locator('#cog-share-btn').click()
+
+    copiedUrl = await page.evaluate(() => window._copiedUrl)
+    const params = new URL(copiedUrl).searchParams
+    expect(params.get('bands')).toBeTruthy()
+
+    // bands 파라미터가 쉼표로 구분된 숫자 형식인지 확인
+    const bands = params.get('bands').split(',').map(Number)
+    expect(bands.length).toBeGreaterThan(0)
+    expect(bands.every(b => Number.isInteger(b) && b >= 1)).toBe(true)
+  })
+
+  test('bands URL 파라미터로 밴드 설정 복원', async ({ page }) => {
+    // bands=3,2,1로 접속 (역순 RGB)
+    await page.goto('?bands=3,2,1')
+    await waitForCogReady(page)
+
+    // window._currentViewerState.bandInfo가 URL 파라미터를 반영하는지 확인
+    const bandInfo = await page.evaluate(() => window._currentViewerState?.bandInfo)
+    expect(bandInfo).toBeTruthy()
+    expect(bandInfo.bands).toEqual([3, 2, 1])
+    expect(bandInfo.type).toBe('rgb')
+  })
+
+  test('단일 밴드 bands 파라미터 복원', async ({ page }) => {
+    // bands=2로 접속 (단일 밴드)
+    await page.goto('?bands=2')
+    await waitForCogReady(page)
+
+    const bandInfo = await page.evaluate(() => window._currentViewerState?.bandInfo)
+    expect(bandInfo).toBeTruthy()
+    expect(bandInfo.bands).toEqual([2])
+    expect(bandInfo.type).toBe('gray')
+  })
+})
+
 test.describe('투영 모드 토글', () => {
 
   test('Affine ↔ Reproject 전환', async ({ page }) => {


### PR DESCRIPTION
## Summary
- 공유 URL 생성 시 `bands` 파라미터 포함 (예: `?bands=1,2,3` 또는 `?bands=4`)
- URL `bands` 파라미터로 앱 시작 시 밴드 설정 자동 복원 (RGB/단일 밴드)
- E2E 테스트 3건 추가

## 변경 파일
- `src/main.js` — URL 파라미터 파싱, 초기 로드 적용, 공유 URL 생성 시 포함
- `tests/viewer/viewer-controls.spec.js` — 밴드 URL 파라미터 E2E 테스트

## Test plan
- [x] `?bands=3,2,1` 접속 시 역순 RGB 밴드로 렌더링 확인
- [x] `?bands=2` 접속 시 단일 밴드(grayscale) 렌더링 확인
- [x] 공유 버튼 클릭 시 URL에 `bands` 파라미터 포함 확인
- [x] E2E 테스트 3건 통과 (`npx playwright test --config playwright.viewer.config.js --grep "밴드 URL"`)

closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)