### PR TITLE
feat: 오프라인 상태 감지 및 폴백 UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,6 +223,11 @@
     .offline-banner.active {
       transform: translateY(0);
     }
+
+    [data-requires-network][disabled] {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
     
     .controls {
       position: absolute;
@@ -1425,9 +1430,9 @@
       <div class="header-url">
         <label for="cog-url-input" class="sr-only">COG URL</label>
         <input type="text" id="cog-url-input" placeholder="COG URL 입력" aria-label="COG 영상 URL 입력">
-        <button id="cog-url-load" aria-label="COG 영상 로드">로드</button>
+        <button id="cog-url-load" aria-label="COG 영상 로드" data-requires-network>로드</button>
         <button id="cog-share-btn" title="현재 뷰 공유" aria-label="현재 뷰 공유 URL 복사">공유</button>
-        <button id="cog-register-btn" style="display:none" aria-label="카탈로그에 COG 등록">등록</button>
+        <button id="cog-register-btn" style="display:none" aria-label="카탈로그에 COG 등록" data-requires-network>등록</button>
       </div>
     </header>
     <div id="map" role="application" aria-label="COG 영상 지도 뷰어"></div>
@@ -1603,7 +1608,7 @@
           <input type="date" id="stac-date-from" title="시작일">
           <input type="date" id="stac-date-to" title="종료일">
         </div>
-        <button id="stac-search-btn" class="stac-search-btn">검색</button>
+        <button id="stac-search-btn" class="stac-search-btn" data-requires-network>검색</button>
       </div>
       <div id="stac-status" class="stac-status"></div>
       <div id="stac-results" class="stac-results"></div>

--- a/src/offline.js
+++ b/src/offline.js
@@ -1,11 +1,37 @@
 const banner = document.getElementById('offline-banner')
 
-function setOffline(offline) {
+let offline = !navigator.onLine
+
+function setOffline(value) {
+  offline = value
   banner.classList.toggle('active', offline)
+  updateNetworkDependentUI()
+  document.dispatchEvent(new CustomEvent('offline-status-changed', { detail: { offline } }))
+}
+
+function updateNetworkDependentUI() {
+  const elements = document.querySelectorAll('[data-requires-network]')
+  elements.forEach(el => {
+    if (offline) {
+      el.dataset.offlineDisabled = el.disabled ? 'was-disabled' : 'was-enabled'
+      el.disabled = true
+      el.title = '오프라인 상태에서는 사용할 수 없습니다'
+    } else {
+      if (el.dataset.offlineDisabled === 'was-enabled') {
+        el.disabled = false
+      }
+      delete el.dataset.offlineDisabled
+      el.title = ''
+    }
+  })
 }
 
 window.addEventListener('offline', () => setOffline(true))
 window.addEventListener('online', () => setOffline(false))
 
 // 초기 상태 반영
-if (!navigator.onLine) setOffline(true)
+if (offline) setOffline(true)
+
+export function isOffline() {
+  return offline
+}

--- a/tests/unit/offline.test.js
+++ b/tests/unit/offline.test.js
@@ -1,10 +1,19 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+let listeners = []
+const origAddEventListener = window.addEventListener.bind(window)
+const origRemoveEventListener = window.removeEventListener.bind(window)
 
 function setupDOM() {
-  document.body.innerHTML = `<div id="offline-banner"></div>`
+  document.body.innerHTML = `
+    <div id="offline-banner"></div>
+    <button id="btn1" data-requires-network>Load</button>
+    <button id="btn2" data-requires-network>Search</button>
+    <button id="btn3">Normal</button>
+  `
 }
 
 async function loadOffline() {
@@ -15,8 +24,22 @@ async function loadOffline() {
 describe('offline.js', () => {
   beforeEach(() => {
     setupDOM()
-    // 기본값: 온라인
     Object.defineProperty(navigator, 'onLine', { value: true, configurable: true, writable: true })
+    // window 이벤트 리스너 추적
+    listeners = []
+    window.addEventListener = (type, handler, opts) => {
+      listeners.push({ type, handler, opts })
+      origAddEventListener(type, handler, opts)
+    }
+  })
+
+  afterEach(() => {
+    // 추적된 리스너 정리
+    listeners.forEach(({ type, handler, opts }) => {
+      origRemoveEventListener(type, handler, opts)
+    })
+    listeners = []
+    window.addEventListener = origAddEventListener
   })
 
   it('초기 온라인 상태에서 배너에 active 클래스 없음', async () => {
@@ -45,5 +68,63 @@ describe('offline.js', () => {
     window.dispatchEvent(new Event('online'))
     const banner = document.getElementById('offline-banner')
     expect(banner.classList.contains('active')).toBe(false)
+  })
+
+  it('isOffline()이 현재 상태를 반환', async () => {
+    const { isOffline } = await loadOffline()
+    expect(isOffline()).toBe(false)
+    window.dispatchEvent(new Event('offline'))
+    expect(isOffline()).toBe(true)
+    window.dispatchEvent(new Event('online'))
+    expect(isOffline()).toBe(false)
+  })
+
+  it('오프라인 시 data-requires-network 버튼이 비활성화됨', async () => {
+    await loadOffline()
+    const btn1 = document.getElementById('btn1')
+    const btn2 = document.getElementById('btn2')
+    const btn3 = document.getElementById('btn3')
+
+    expect(btn1.disabled).toBe(false)
+    expect(btn2.disabled).toBe(false)
+
+    window.dispatchEvent(new Event('offline'))
+    expect(btn1.disabled).toBe(true)
+    expect(btn2.disabled).toBe(true)
+    expect(btn3.disabled).toBe(false)
+    expect(btn1.title).toBe('오프라인 상태에서는 사용할 수 없습니다')
+  })
+
+  it('온라인 복귀 시 버튼이 다시 활성화됨', async () => {
+    await loadOffline()
+    window.dispatchEvent(new Event('offline'))
+    window.dispatchEvent(new Event('online'))
+
+    const btn1 = document.getElementById('btn1')
+    expect(btn1.disabled).toBe(false)
+    expect(btn1.title).toBe('')
+  })
+
+  it('원래 disabled 상태였던 버튼은 온라인 복귀 후에도 disabled 유지', async () => {
+    await loadOffline()
+    const btn1 = document.getElementById('btn1')
+    btn1.disabled = true
+
+    window.dispatchEvent(new Event('offline'))
+    expect(btn1.disabled).toBe(true)
+
+    window.dispatchEvent(new Event('online'))
+    expect(btn1.disabled).toBe(true)
+  })
+
+  it('offline-status-changed 커스텀 이벤트가 발생함', async () => {
+    await loadOffline()
+    const events = []
+    document.addEventListener('offline-status-changed', (e) => events.push(e.detail))
+
+    window.dispatchEvent(new Event('offline'))
+    window.dispatchEvent(new Event('online'))
+
+    expect(events).toEqual([{ offline: true }, { offline: false }])
   })
 })

--- a/tests/viewer/offline-ui.spec.js
+++ b/tests/viewer/offline-ui.spec.js
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('오프라인 상태 감지 및 폴백 UI', () => {
+
+  test('오프라인 전환 시 배너 표시 및 서버 의존 버튼 비활성화', async ({ page, context }) => {
+    await page.goto('')
+    // 초기: 온라인 상태, 배너 숨김
+    const banner = page.locator('#offline-banner')
+    await expect(banner).not.toHaveClass(/active/)
+
+    const loadBtn = page.locator('#cog-url-load')
+    const stacSearchBtn = page.locator('#stac-search-btn')
+    await expect(loadBtn).toBeEnabled()
+
+    // 오프라인 전환
+    await context.setOffline(true)
+
+    await expect(banner).toHaveClass(/active/)
+    await expect(loadBtn).toBeDisabled()
+    await expect(stacSearchBtn).toBeDisabled()
+  })
+
+  test('온라인 복귀 시 배너 해제 및 버튼 재활성화', async ({ page, context }) => {
+    await page.goto('')
+
+    // 오프라인 전환
+    await context.setOffline(true)
+    const banner = page.locator('#offline-banner')
+    await expect(banner).toHaveClass(/active/)
+
+    // 온라인 복귀
+    await context.setOffline(false)
+    await expect(banner).not.toHaveClass(/active/)
+    await expect(page.locator('#cog-url-load')).toBeEnabled()
+    await expect(page.locator('#stac-search-btn')).toBeEnabled()
+  })
+
+  test('오프라인 상태에서 비활성화된 버튼에 안내 tooltip 표시', async ({ page, context }) => {
+    await page.goto('')
+    await context.setOffline(true)
+
+    const loadBtn = page.locator('#cog-url-load')
+    await expect(loadBtn).toHaveAttribute('title', '오프라인 상태에서는 사용할 수 없습니다')
+  })
+})


### PR DESCRIPTION
## Summary
- 네트워크 상태 감지(`navigator.onLine` + `online`/`offline` 이벤트)로 오프라인 배너 자동 표시/해제
- `data-requires-network` 속성으로 서버 의존 버튼(COG 로드, 등록, STAC 검색) 오프라인 시 자동 비활성화 + tooltip 안내
- `isOffline()` export 및 `offline-status-changed` 커스텀 이벤트로 다른 모듈에서 활용 가능

## Test plan
- [x] 단위 테스트 9개 통과 (배너 표시, 버튼 비활성화/복원, 이벤트 발생)
- [x] E2E 테스트 3개 통과 (Playwright `context.setOffline()` 활용)
- [x] 기존 E2E 테스트 12개 전체 통과

closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)