### PR TITLE
fix: 오프라인 복귀 시 기존 title 복원 (#163)

### DIFF
--- a/src/offline.js
+++ b/src/offline.js
@@ -14,14 +14,16 @@ function updateNetworkDependentUI() {
   elements.forEach(el => {
     if (offline) {
       el.dataset.offlineDisabled = el.disabled ? 'was-disabled' : 'was-enabled'
+      el.dataset.offlineTitle = el.title
       el.disabled = true
       el.title = '오프라인 상태에서는 사용할 수 없습니다'
     } else {
       if (el.dataset.offlineDisabled === 'was-enabled') {
         el.disabled = false
       }
+      el.title = el.dataset.offlineTitle ?? ''
       delete el.dataset.offlineDisabled
-      el.title = ''
+      delete el.dataset.offlineTitle
     }
   })
 }

--- a/tests/unit/offline.test.js
+++ b/tests/unit/offline.test.js
@@ -105,6 +105,18 @@ describe('offline.js', () => {
     expect(btn1.title).toBe('')
   })
 
+  it('기존 title이 있는 버튼은 온라인 복귀 시 원래 title 복원', async () => {
+    const btn1 = document.getElementById('btn1')
+    btn1.title = '데이터 로드'
+
+    await loadOffline()
+    window.dispatchEvent(new Event('offline'))
+    expect(btn1.title).toBe('오프라인 상태에서는 사용할 수 없습니다')
+
+    window.dispatchEvent(new Event('online'))
+    expect(btn1.title).toBe('데이터 로드')
+  })
+
   it('원래 disabled 상태였던 버튼은 온라인 복귀 후에도 disabled 유지', async () => {
     await loadOffline()
     const btn1 = document.getElementById('btn1')


### PR DESCRIPTION
## Summary
- 오프라인 진입 시 `dataset.offlineTitle`에 기존 `title`을 저장하고, 온라인 복귀 시 복원
- 기존에는 `el.title = ''`로 하드코딩되어 원래 title이 소실되는 문제 수정

## Test plan
- [x] 기존 title이 없는 버튼: 온라인 복귀 시 `title = ''` (기존 동작 유지)
- [x] 기존 title이 있는 버튼: 온라인 복귀 시 원래 title 복원 (새 테스트 추가)
- [x] 기존 10개 테스트 모두 통과

closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)