### PR TITLE
test: catalog.js, auth.js, watchlist.js 테스트 커버리지 개선

### DIFF
--- a/tests/unit/auth-no-supabase.test.js
+++ b/tests/unit/auth-no-supabase.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../src/supabase.js', () => ({ supabase: null }))
+vi.mock('../../src/constants.js', () => ({ PRE_LOGIN_STATE_KEY: 'cognito-pre-login-state' }))
+
+import { signIn, signOut, signInWithEmail, signUpWithEmail, getSession, onAuthStateChange } from '../../src/auth.js'
+
+describe('auth functions when supabase is null', () => {
+  it('signIn returns undefined', async () => {
+    expect(await signIn('google')).toBeUndefined()
+  })
+
+  it('signOut returns undefined', async () => {
+    expect(await signOut()).toBeUndefined()
+  })
+
+  it('signInWithEmail returns error', async () => {
+    const result = await signInWithEmail('a@b.com', 'pass')
+    expect(result.error.message).toBe('Supabase 미설정')
+  })
+
+  it('signUpWithEmail returns error', async () => {
+    const result = await signUpWithEmail('a@b.com', 'pass')
+    expect(result.error.message).toBe('Supabase 미설정')
+  })
+
+  it('getSession returns null', async () => {
+    expect(await getSession()).toBeNull()
+  })
+
+  it('onAuthStateChange returns noop subscription', () => {
+    const result = onAuthStateChange(() => {})
+    expect(result.data.subscription.unsubscribe).toBeInstanceOf(Function)
+  })
+})

--- a/tests/unit/auth.test.js
+++ b/tests/unit/auth.test.js
@@ -71,6 +71,34 @@ describe('auth functions with mocked supabase', () => {
     }
   })
 
+  it('signIn logs error when signInWithOAuth fails', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockAuth.signInWithOAuth.mockResolvedValueOnce({ error: { message: 'OAuth error' } })
+
+    await signIn('google')
+    expect(consoleSpy).toHaveBeenCalledWith('Sign in error:', 'OAuth error')
+    consoleSpy.mockRestore()
+  })
+
+  it('signOut logs error when signOut fails', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockAuth.signOut.mockResolvedValueOnce({ error: { message: 'Sign out error' } })
+
+    await signOut()
+    expect(consoleSpy).toHaveBeenCalledWith('Sign out error:', 'Sign out error')
+    consoleSpy.mockRestore()
+  })
+
+  it('signIn saves state with cogUrl only (no olMap)', async () => {
+    globalThis.window.currentCogMeta = { url: 'https://example.com/test.tif' }
+    globalThis.window.olMap = undefined
+
+    await signIn('google')
+    const saved = JSON.parse(sessionStorage.getItem('cognito-pre-login-state'))
+    expect(saved.cogUrl).toBe('https://example.com/test.tif')
+    expect(saved.center).toBeUndefined()
+  })
+
   it('signIn calls signInWithOAuth and saves pre-login state', async () => {
     globalThis.window = globalThis.window || {}
     globalThis.window.currentCogMeta = { url: 'https://example.com/test.tif' }

--- a/tests/unit/catalog.test.js
+++ b/tests/unit/catalog.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const { mockSupabase, setMockQuery, createQueryMock, mockDetectBands } = vi.hoisted(() => {
   let mockQuery
@@ -19,7 +19,13 @@ const { mockSupabase, setMockQuery, createQueryMock, mockDetectBands } = vi.hois
     }
     return chain
   }
-  const mockSupabase = { from: vi.fn(() => mockQuery) }
+  const mockStorage = {
+    from: vi.fn().mockReturnValue({
+      upload: vi.fn().mockResolvedValue({ error: null }),
+      getPublicUrl: vi.fn().mockReturnValue({ data: { publicUrl: 'https://cdn.example.com/thumb.png' } }),
+    }),
+  }
+  const mockSupabase = { from: vi.fn(() => mockQuery), storage: mockStorage }
   return {
     mockSupabase,
     setMockQuery: (q) => { mockQuery = q; mockSupabase.from = vi.fn(() => q) },
@@ -31,7 +37,64 @@ const { mockSupabase, setMockQuery, createQueryMock, mockDetectBands } = vi.hois
 vi.mock('../../src/supabase.js', () => ({ supabase: mockSupabase }))
 vi.mock('@conaonda/ol-cog-layers', () => ({ detectBands: mockDetectBands }))
 
-import { generateTitleFromUrl, generateDescriptionFromMeta, saveCogImage, getCogImages, getCogImage, deleteCogImage, extractCogMetadata, generateThumbnail } from '../../src/catalog.js'
+import { uploadThumbnail, generateTitleFromUrl, generateDescriptionFromMeta, saveCogImage, getCogImages, getCogImage, deleteCogImage, extractCogMetadata, generateThumbnail } from '../../src/catalog.js'
+
+describe('uploadThumbnail', () => {
+  beforeEach(() => {
+    // Reset storage mocks
+    const bucket = {
+      upload: vi.fn().mockResolvedValue({ error: null }),
+      getPublicUrl: vi.fn().mockReturnValue({ data: { publicUrl: 'https://cdn.example.com/thumb.png' } }),
+    }
+    mockSupabase.storage.from = vi.fn().mockReturnValue(bucket)
+
+    // Mock global fetch for data URL conversion
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      blob: () => Promise.resolve(new Blob(['fake'], { type: 'image/png' })),
+    })
+    // Mock crypto.randomUUID
+    vi.stubGlobal('crypto', { randomUUID: vi.fn().mockReturnValue('test-uuid') })
+  })
+
+  it('uploads thumbnail and returns public URL', async () => {
+    const result = await uploadThumbnail('data:image/png;base64,abc')
+    expect(mockSupabase.storage.from).toHaveBeenCalledWith('cog-thumbnails')
+    expect(result).toBe('https://cdn.example.com/thumb.png')
+  })
+
+  it('returns null on upload error', async () => {
+    const bucket = {
+      upload: vi.fn().mockResolvedValue({ error: { message: 'upload failed' } }),
+      getPublicUrl: vi.fn(),
+    }
+    mockSupabase.storage.from = vi.fn().mockReturnValue(bucket)
+
+    const result = await uploadThumbnail('data:image/png;base64,abc')
+    expect(result).toBeNull()
+  })
+
+  it('returns null on fetch error', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('network error'))
+
+    const result = await uploadThumbnail('data:image/png;base64,abc')
+    expect(result).toBeNull()
+  })
+
+  it('uses jpg extension for non-png blobs', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      blob: () => Promise.resolve(new Blob(['fake'], { type: 'image/jpeg' })),
+    })
+    const uploadFn = vi.fn().mockResolvedValue({ error: null })
+    const bucket = {
+      upload: uploadFn,
+      getPublicUrl: vi.fn().mockReturnValue({ data: { publicUrl: 'https://cdn.example.com/thumb.jpg' } }),
+    }
+    mockSupabase.storage.from = vi.fn().mockReturnValue(bucket)
+
+    await uploadThumbnail('data:image/jpeg;base64,abc')
+    expect(uploadFn).toHaveBeenCalledWith('test-uuid.jpg', expect.any(Blob), expect.any(Object))
+  })
+})
 
 describe('generateTitleFromUrl', () => {
   it('removes .tif extension and converts separators to spaces', () => {
@@ -56,6 +119,11 @@ describe('generateTitleFromUrl', () => {
 
   it('returns empty string for empty/invalid input', () => {
     expect(generateTitleFromUrl('')).toBe('')
+  })
+
+  it('returns empty string when URL causes an exception', () => {
+    // null.split() will throw
+    expect(generateTitleFromUrl(null)).toBe('')
   })
 
   it('handles URL with no extension', () => {

--- a/tests/unit/watchlist-no-supabase.test.js
+++ b/tests/unit/watchlist-no-supabase.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../src/supabase.js', () => ({ supabase: null }))
+
+import { getWatchlists, createWatchlist, deleteWatchlist, addItem, removeItem, getWatchlistItems } from '../../src/watchlist.js'
+
+describe('watchlist functions when supabase is null', () => {
+  it('getWatchlists returns empty data', async () => {
+    const result = await getWatchlists()
+    expect(result).toEqual({ data: [], error: null })
+  })
+
+  it('createWatchlist returns error', async () => {
+    const result = await createWatchlist('Test')
+    expect(result).toEqual({ data: null, error: { message: 'Supabase 미설정' } })
+  })
+
+  it('deleteWatchlist returns error', async () => {
+    const result = await deleteWatchlist('wl-1')
+    expect(result).toEqual({ error: { message: 'Supabase 미설정' } })
+  })
+
+  it('addItem returns error', async () => {
+    const result = await addItem('wl-1', 'img-1')
+    expect(result).toEqual({ error: { message: 'Supabase 미설정' } })
+  })
+
+  it('removeItem returns error', async () => {
+    const result = await removeItem('wl-1', 'img-1')
+    expect(result).toEqual({ error: { message: 'Supabase 미설정' } })
+  })
+
+  it('getWatchlistItems returns empty data', async () => {
+    const result = await getWatchlistItems('wl-1')
+    expect(result).toEqual({ data: [], error: null })
+  })
+})


### PR DESCRIPTION
## Summary
- catalog.js 구문 커버리지 91.39% → 100% 달성 (`uploadThumbnail` 테스트, `generateTitleFromUrl` catch 분기 커버)
- auth.js 브랜치 커버리지 63.63% → 100% 달성 (supabase null 가드, 에러 로깅 분기)
- watchlist.js 브랜치 커버리지 62.5% → 100% 달성 (supabase null 가드 전 함수)

closes #183, closes #184

## Test plan
- [x] 기존 202개 테스트 전체 통과
- [x] catalog.js Stmts 100%
- [x] auth.js Branch 100%
- [x] watchlist.js Branch 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)