### PR TITLE
test: viewerControls/likes/catalog 브랜치 커버리지 90% 이상 개선

### DIFF
--- a/tests/unit/catalog.test.js
+++ b/tests/unit/catalog.test.js
@@ -395,6 +395,128 @@ describe('extractCogMetadata', () => {
   })
 })
 
+describe('supabase null guards', () => {
+  let nullMod
+  beforeEach(async () => {
+    vi.doMock('../../src/supabase.js', () => ({ supabase: null }))
+    vi.resetModules()
+    nullMod = await import('../../src/catalog.js')
+  })
+
+  it('uploadThumbnail returns null', async () => {
+    expect(await nullMod.uploadThumbnail('data:image/png;base64,abc')).toBeNull()
+  })
+
+  it('saveCogImage returns error', async () => {
+    const result = await nullMod.saveCogImage({ url: 'test' })
+    expect(result.error.message).toBe('Supabase 미설정')
+  })
+
+  it('getCogImages returns empty array', async () => {
+    const result = await nullMod.getCogImages()
+    expect(result).toEqual({ data: [], error: null })
+  })
+
+  it('getCogImage returns null data', async () => {
+    const result = await nullMod.getCogImage('123')
+    expect(result).toEqual({ data: null, error: null })
+  })
+
+  it('deleteCogImage returns error', async () => {
+    const result = await nullMod.deleteCogImage('123')
+    expect(result.error.message).toBe('Supabase 미설정')
+  })
+})
+
+describe('saveCogImage — field defaults', () => {
+  it('uses default values for optional fields', async () => {
+    const q = createQueryMock({ id: '1', url: 'test' })
+    setMockQuery(q)
+    await saveCogImage({ url: 'test' })
+    const insertArg = q.insert.mock.calls[0][0]
+    expect(insertArg.title).toBeNull()
+    expect(insertArg.tags).toEqual([])
+    expect(insertArg.source_type).toBe('manual')
+  })
+})
+
+describe('getCogImages — like_count sort edge cases', () => {
+  it('handles items with missing likes array', async () => {
+    const q = createQueryMock([
+      { id: '1', likes: null },
+      { id: '2', likes: [{ count: 3 }] },
+      { id: '3' },
+    ])
+    setMockQuery(q)
+    const result = await getCogImages({ sortBy: 'like_count' })
+    expect(result.data[0].id).toBe('2')
+  })
+})
+
+describe('extractCogMetadata — date edge cases', () => {
+  it('returns null for invalid date range in URL', async () => {
+    const mockImage = {
+      getGeoKeys: () => ({}),
+      getBoundingBox: () => [0, 0, 1, 1],
+      getWidth: () => 256,
+      getHeight: () => 256,
+      getFileDirectory: () => ({}),
+    }
+    const mockTiff = { getImage: vi.fn().mockResolvedValue(mockImage) }
+    mockDetectBands.mockResolvedValue({ type: 'gray', bands: [1] })
+
+    // Month 13 is invalid
+    const result = await extractCogMetadata(mockTiff, 'https://example.com/1990-13-01_scene.tif')
+    expect(result.captured_at).toBeNull()
+  })
+
+  it('returns null for parseTiffDate when date is invalid (NaN)', async () => {
+    const mockImage = {
+      getGeoKeys: () => ({}),
+      getBoundingBox: () => [0, 0, 1, 1],
+      getWidth: () => 256,
+      getHeight: () => 256,
+      getFileDirectory: () => ({ GDAL_METADATA: '<Item name="TIFFTAG_DATETIME">2023:00:00 00:00:00</Item>' }),
+    }
+    const mockTiff = { getImage: vi.fn().mockResolvedValue(mockImage) }
+    mockDetectBands.mockResolvedValue({ type: 'gray', bands: [1] })
+
+    const result = await extractCogMetadata(mockTiff)
+    // Month 00 creates an invalid date — parseTiffDate returns null, falls through
+    expect(result.captured_at).toBeNull()
+  })
+
+  it('returns null for URL date with year < 1970', async () => {
+    const mockImage = {
+      getGeoKeys: () => ({}),
+      getBoundingBox: () => [0, 0, 1, 1],
+      getWidth: () => 256,
+      getHeight: () => 256,
+      getFileDirectory: () => ({}),
+    }
+    const mockTiff = { getImage: vi.fn().mockResolvedValue(mockImage) }
+    mockDetectBands.mockResolvedValue({ type: 'gray', bands: [1] })
+
+    const result = await extractCogMetadata(mockTiff, 'https://example.com/1960-06-15_scene.tif')
+    expect(result.captured_at).toBeNull()
+  })
+
+  it('returns null for parseTiffDate with non-matching string', async () => {
+    const mockImage = {
+      getGeoKeys: () => ({}),
+      getBoundingBox: () => [0, 0, 1, 1],
+      getWidth: () => 256,
+      getHeight: () => 256,
+      getFileDirectory: () => ({ GDAL_METADATA: '<Item name="TIFFTAG_DATETIME">not-a-date</Item>' }),
+    }
+    const mockTiff = { getImage: vi.fn().mockResolvedValue(mockImage) }
+    mockDetectBands.mockResolvedValue({ type: 'gray', bands: [1] })
+
+    const result = await extractCogMetadata(mockTiff)
+    expect(result.captured_at).toBeNull()
+  })
+})
+
 describe('generateThumbnail', () => {
   function mockCanvas() {
     const imgData = { data: new Uint8ClampedArray(128 * 128 * 4) }
@@ -459,6 +581,44 @@ describe('generateThumbnail', () => {
     }
     const result = await generateThumbnail(mockTiff)
     expect(result).toBeNull()
+  })
+
+  it('handles constant-value bands (max === min)', async () => {
+    mockCanvas()
+    const rasters = [
+      new Float32Array([50, 50, 50, 50]),
+      new Float32Array([50, 50, 50, 50]),
+      new Float32Array([50, 50, 50, 50]),
+    ]
+    const mockImage = {
+      getWidth: () => 2,
+      getHeight: () => 2,
+      readRasters: vi.fn().mockResolvedValue(rasters),
+    }
+    const mockTiff = {
+      getImageCount: vi.fn().mockResolvedValue(1),
+      getImage: vi.fn().mockResolvedValue(mockImage),
+    }
+
+    const result = await generateThumbnail(mockTiff)
+    expect(result).toBe('data:image/png;base64,fake')
+  })
+
+  it('handles constant-value grayscale band (max === min)', async () => {
+    mockCanvas()
+    const rasters = [new Float32Array([42, 42, 42, 42])]
+    const mockImage = {
+      getWidth: () => 2,
+      getHeight: () => 2,
+      readRasters: vi.fn().mockResolvedValue(rasters),
+    }
+    const mockTiff = {
+      getImageCount: vi.fn().mockResolvedValue(1),
+      getImage: vi.fn().mockResolvedValue(mockImage),
+    }
+
+    const result = await generateThumbnail(mockTiff)
+    expect(result).toBe('data:image/png;base64,fake')
   })
 
   it('handles grayscale (single band) tiff', async () => {

--- a/tests/unit/likes.test.js
+++ b/tests/unit/likes.test.js
@@ -139,6 +139,55 @@ describe('isLiked', () => {
   })
 })
 
+describe('supabase null guard', () => {
+  let nullMod
+  beforeEach(async () => {
+    vi.doMock('../../src/supabase.js', () => ({ supabase: null }))
+    vi.resetModules()
+    nullMod = await import('../../src/likes.js')
+  })
+
+  it('toggleLike returns error when supabase is null', async () => {
+    const result = await nullMod.toggleLike('img-1')
+    expect(result).toEqual({ liked: false, error: { message: 'Supabase 미설정' } })
+  })
+
+  it('getLikeCount returns 0 when supabase is null', async () => {
+    expect(await nullMod.getLikeCount('img-1')).toBe(0)
+  })
+
+  it('isLiked returns false when supabase is null', async () => {
+    expect(await nullMod.isLiked('img-1')).toBe(false)
+  })
+})
+
+describe('getLikeStates — null data fallback', () => {
+  it('handles null likes data gracefully', async () => {
+    mockSession(testSession)
+
+    const likesQ = {
+      select: vi.fn().mockReturnThis(),
+      in: vi.fn().mockReturnThis(),
+      then: (resolve) => resolve({ data: null }),
+    }
+    const userLikesQ = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      in: vi.fn().mockReturnThis(),
+      then: (resolve) => resolve({ data: null }),
+    }
+
+    let callCount = 0
+    mockSupabase.from = vi.fn(() => {
+      callCount++
+      return callCount === 1 ? likesQ : userLikesQ
+    })
+
+    const result = await getLikeStates(['img-1'])
+    expect(result.get('img-1')).toEqual({ count: 0, liked: false })
+  })
+})
+
 describe('getLikeStates', () => {
   it('returns empty map for empty ids', async () => {
     const result = await getLikeStates([])

--- a/tests/unit/viewerControls.test.js
+++ b/tests/unit/viewerControls.test.js
@@ -342,6 +342,149 @@ describe('viewerControls', () => {
     })
   })
 
+  describe('edge cases — missing DOM elements', () => {
+    it('initViewerControls returns early when panel is missing', () => {
+      document.body.innerHTML = ''
+      expect(() => initViewerControls(vi.fn(), vi.fn())).not.toThrow()
+    })
+
+    it('reset button does nothing when currentStats is null', () => {
+      const onStyleChange = vi.fn()
+      initViewerControls(onStyleChange, vi.fn())
+      // No updateControlsForCog called, so currentStats is null
+      onStyleChange.mockClear()
+      document.getElementById('vc-reset-btn').dispatchEvent(new Event('click'))
+      expect(onStyleChange).not.toHaveBeenCalled()
+    })
+
+    it('getCurrentStyle falls back when band selectors are missing', () => {
+      initViewerControls(vi.fn(), vi.fn())
+      // Remove band selectors
+      document.getElementById('vc-band-r')?.remove()
+      document.getElementById('vc-band-g')?.remove()
+      document.getElementById('vc-band-b')?.remove()
+      const bandMode = document.getElementById('vc-band-mode')
+      bandMode.value = 'rgb'
+
+      const style = getCurrentStyle()
+      expect(style.bands).toEqual([1, 2, 3])
+    })
+
+    it('getCurrentStyle falls back when single band selector is missing', () => {
+      initViewerControls(vi.fn(), vi.fn())
+      document.getElementById('vc-band-single')?.remove()
+      const bandMode = document.getElementById('vc-band-mode')
+      bandMode.value = 'single'
+
+      const style = getCurrentStyle()
+      expect(style.bands).toEqual([1])
+    })
+
+    it('getCurrentStyle falls back when sliders are missing', () => {
+      initViewerControls(vi.fn(), vi.fn())
+      document.getElementById('vc-min-slider')?.remove()
+      document.getElementById('vc-max-slider')?.remove()
+      const bandMode = document.getElementById('vc-band-mode')
+      bandMode.value = 'single'
+
+      const style = getCurrentStyle()
+      expect(style.min).toBe(0)
+      expect(style.max).toBe(1)
+    })
+
+    it('getCurrentStyle falls back when colormap is missing', () => {
+      initViewerControls(vi.fn(), vi.fn())
+      document.getElementById('vc-colormap')?.remove()
+
+      const style = getCurrentStyle()
+      expect(style.colormap).toBe('grayscale')
+    })
+
+    it('getCurrentStyle perband falls back when perband inputs are missing', () => {
+      initViewerControls(vi.fn(), vi.fn())
+      updateControlsForCog(3, { type: 'rgb', bands: [1, 2, 3] }, [
+        { min: 0, max: 100 }, { min: 0, max: 100 }, { min: 0, max: 100 }
+      ], 'affine')
+
+      // Switch to perband
+      const perbandRadio = document.querySelector('input[name="vc-stretch-mode"][value="perband"]')
+      perbandRadio.checked = true
+      perbandRadio.dispatchEvent(new Event('change'))
+
+      // Remove perband inputs
+      document.querySelectorAll('.vc-perband-min').forEach(el => el.remove())
+      document.querySelectorAll('.vc-perband-max').forEach(el => el.remove())
+
+      const style = getCurrentStyle()
+      expect(style.stats[0].min).toBe(0)
+      expect(style.stats[0].max).toBe(1)
+    })
+
+    it('updateBandSelectors returns early when bandMode is missing', () => {
+      initViewerControls(vi.fn(), vi.fn())
+      // Set up band options first, then remove bandMode
+      updateControlsForCog(3, { type: 'rgb', bands: [1, 2, 3] }, [
+        { min: 0, max: 1 }, { min: 0, max: 1 }, { min: 0, max: 1 }
+      ], 'affine')
+      document.getElementById('vc-band-mode').remove()
+      // Trigger bandMode change on a band selector — this calls emitStyleChange which calls getCurrentStyle
+      // but updateBandSelectors is called from populateBandOptions, test the early return
+      const selR = document.getElementById('vc-band-r')
+      if (selR) {
+        expect(() => selR.dispatchEvent(new Event('change'))).not.toThrow()
+      }
+    })
+
+    it('stretch mode change handles missing batch/perband groups', () => {
+      // Set up DOM without vc-stretch-batch and vc-stretch-perband containers
+      const panel = document.getElementById('viewer-controls-panel')
+      document.getElementById('vc-stretch-batch')?.remove()
+      document.getElementById('vc-stretch-perband')?.remove()
+
+      initViewerControls(vi.fn(), vi.fn())
+      updateControlsForCog(3, { type: 'rgb', bands: [1, 2, 3] }, [
+        { min: 0, max: 100 }, { min: 0, max: 100 }, { min: 0, max: 100 }
+      ], 'affine')
+
+      // batch radio change — batchGroup and perbandGroup are null
+      const batchRadio = document.querySelector('input[name="vc-stretch-mode"][value="batch"]')
+      batchRadio.checked = true
+      expect(() => batchRadio.dispatchEvent(new Event('change'))).not.toThrow()
+    })
+
+    it('populateBandOptions skips missing selectors', () => {
+      initViewerControls(vi.fn(), vi.fn())
+      // Remove one selector before populating
+      document.getElementById('vc-band-r')?.remove()
+      expect(() => updateControlsForCog(3, { type: 'rgb', bands: [1, 2, 3] }, [
+        { min: 0, max: 1 }, { min: 0, max: 1 }, { min: 0, max: 1 }
+      ], 'affine')).not.toThrow()
+    })
+
+    it('setControlsEnabled returns early when panel is missing', () => {
+      initViewerControls(vi.fn(), vi.fn())
+      // Remove panel and call updateControlsForCog which calls setControlsEnabled
+      const panel = document.getElementById('viewer-controls-panel')
+      panel.id = 'removed'
+      expect(() => updateControlsForCog(3, { type: 'rgb', bands: [1, 2, 3] }, [
+        { min: 0, max: 1 }, { min: 0, max: 1 }, { min: 0, max: 1 }
+      ], 'affine')).not.toThrow()
+    })
+
+    it('resetSlidersToStats uses stats[0] fallback for excess channels', () => {
+      const onStyleChange = vi.fn()
+      initViewerControls(onStyleChange, vi.fn())
+      // Provide only 1 stat but 3 perband channels exist
+      updateControlsForCog(3, { type: 'rgb', bands: [1, 2, 3] }, [
+        { min: 10, max: 90 }
+      ], 'affine')
+
+      onStyleChange.mockClear()
+      document.getElementById('vc-reset-btn').dispatchEvent(new Event('click'))
+      expect(onStyleChange).toHaveBeenCalled()
+    })
+  })
+
   describe('updateStretchModeVisibility', () => {
     it('RGB일 때 스트레치 모드 선택 표시', () => {
       initViewerControls(vi.fn(), vi.fn())


### PR DESCRIPTION
## Summary
- viewerControls.js 브랜치 커버리지: 73% → 96.62%
- likes.js 브랜치 커버리지: 82.14% → 100%
- catalog.js 브랜치 커버리지: 82.5% → 99.06%

Missing DOM elements, supabase null guards, null data fallbacks, date parsing edge cases, constant-value band rendering 등의 브랜치를 커버하는 테스트 추가.

closes #186
closes #187

## Test plan
- [x] `npx vitest run` 전체 231 테스트 통과
- [x] viewerControls.js 브랜치 커버리지 ≥ 90%
- [x] likes.js 브랜치 커버리지 ≥ 90%
- [x] catalog.js 브랜치 커버리지 ≥ 90%

🤖 Generated with [Claude Code](https://claude.com/claude-code)