### PR TITLE
test: stac/viewerControls 브랜치 커버리지 개선

### DIFF
--- a/tests/unit/stac.test.js
+++ b/tests/unit/stac.test.js
@@ -101,6 +101,23 @@ describe('extractStacItemMeta', () => {
     const item = { ...baseItem, assets: {} }
     expect(extractStacItemMeta(item).cogUrl).toBeNull()
   })
+
+  it('handles item without assets property (defaults to {})', () => {
+    const item = { id: 'no-assets', properties: {} }
+    const meta = extractStacItemMeta(item)
+    expect(meta.cogUrl).toBeNull()
+    expect(meta.thumbnail_url).toBeNull()
+  })
+
+  it('handles asset with undefined href via toHttpUrl', () => {
+    const item = {
+      ...baseItem,
+      assets: { visual: { href: undefined }, thumbnail: { href: undefined } },
+    }
+    const meta = extractStacItemMeta(item)
+    expect(meta.cogUrl).toBeNull()
+    expect(meta.thumbnail_url).toBeNull()
+  })
 })
 
 describe('searchStac', () => {
@@ -134,6 +151,13 @@ describe('searchStac', () => {
     const body = JSON.parse(fetch.mock.calls[0][1].body)
     expect(body.intersects).toEqual(geo)
     expect(body.bbox).toBeUndefined()
+  })
+
+  it('includes datetime when provided', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) })
+    await searchStac({ apiUrl: 'https://api.example.com', datetime: '2024-01-01/2024-12-31' })
+    const body = JSON.parse(fetch.mock.calls[0][1].body)
+    expect(body.datetime).toBe('2024-01-01/2024-12-31')
   })
 
   it('throws on non-ok response', async () => {

--- a/tests/unit/viewerControls.test.js
+++ b/tests/unit/viewerControls.test.js
@@ -452,6 +452,30 @@ describe('viewerControls', () => {
       expect(() => batchRadio.dispatchEvent(new Event('change'))).not.toThrow()
     })
 
+    it('batch stretch mode radio change sets groups visible (isPerband=false)', () => {
+      initViewerControls(vi.fn(), vi.fn())
+      updateControlsForCog(3, { type: 'rgb', bands: [1, 2, 3] }, [
+        { min: 0, max: 100 }, { min: 0, max: 100 }, { min: 0, max: 100 }
+      ], 'affine')
+
+      const batchRadio = document.querySelector('input[name="vc-stretch-mode"][value="batch"]')
+      batchRadio.checked = true
+      batchRadio.dispatchEvent(new Event('change'))
+
+      const batchGroup = document.getElementById('vc-stretch-batch')
+      const perbandGroup = document.getElementById('vc-stretch-perband')
+      expect(batchGroup.style.display).toBe('')
+      expect(perbandGroup.style.display).toBe('none')
+    })
+
+    it('updateControlsForCog works when bandMode element is missing', () => {
+      initViewerControls(vi.fn(), vi.fn())
+      document.getElementById('vc-band-mode')?.remove()
+      expect(() => updateControlsForCog(3, { type: 'rgb', bands: [1, 2, 3] }, [
+        { min: 0, max: 1 }, { min: 0, max: 1 }, { min: 0, max: 1 }
+      ], 'affine')).not.toThrow()
+    })
+
     it('populateBandOptions skips missing selectors', () => {
       initViewerControls(vi.fn(), vi.fn())
       // Remove one selector before populating


### PR DESCRIPTION
## Summary
- stac.js 브랜치 커버리지 94% → 98.18% (datetime, assets 미존재, undefined href 테스트 추가)
- viewerControls.js 브랜치 커버리지 96.62% → 100% (batch radio change, bandMode 미존재 테스트 추가)
- 전체 브랜치 커버리지 97.87% → 99.4%

**미커버 분기 분석:**
- stac.js line 95 (`toHttpUrl`의 `if (!url)` guard): 모든 호출처에서 `isUsableUrl` 체크 후 호출되어 도달 불가능한 방어 코드
- catalog.js line 190 (`extractDateFromUrl`의 `isNaN(date)` 분기): range validation 통과 후 JS `new Date()`가 NaN을 반환하는 것이 불가능

closes #189
closes #190

## Test plan
- [x] 전체 테스트 236개 통과
- [x] viewerControls.js 브랜치 커버리지 100%
- [x] stac.js 브랜치 커버리지 98.18% (도달 불가 방어 코드 제외)

🤖 Generated with [Claude Code](https://claude.com/claude-code)