### PR TITLE
test: 전체 커버리지 100% 달성

### DIFF
--- a/src/catalog.js
+++ b/src/catalog.js
@@ -187,6 +187,7 @@ function extractDateFromUrl(url) {
   const y = parseInt(m[1]), mo = parseInt(m[2]), d = parseInt(m[3])
   if (y < 1970 || y > new Date().getFullYear() + 1 || mo < 1 || mo > 12 || d < 1 || d > 31) return null
   const date = new Date(`${m[1]}-${m[2]}-${m[3]}`)
+  /* v8 ignore next -- 방어 코드: 위 범위 검증으로 유효하지 않은 날짜 도달 불가 */
   return isNaN(date) ? null : date.toISOString()
 }
 

--- a/src/stac.js
+++ b/src/stac.js
@@ -92,6 +92,7 @@ export function extractStacItemMeta(item) {
 
   const isUsableUrl = (url) => url && /^(https?|s3):\/\//.test(url)
   const toHttpUrl = (url) => {
+    /* v8 ignore next -- 방어 코드: isUsableUrl 통과 후 호출되므로 도달 불가 */
     if (!url) return url
     const s3Match = url.match(/^s3:\/\/([^/]+)\/(.+)$/)
     if (s3Match) return `https://${s3Match[1]}.s3.amazonaws.com/${s3Match[2]}`

--- a/tests/unit/auth-no-supabase.test.js
+++ b/tests/unit/auth-no-supabase.test.js
@@ -31,5 +31,7 @@ describe('auth functions when supabase is null', () => {
   it('onAuthStateChange returns noop subscription', () => {
     const result = onAuthStateChange(() => {})
     expect(result.data.subscription.unsubscribe).toBeInstanceOf(Function)
+    // noop unsubscribe 호출하여 함수 커버리지 확보
+    result.data.subscription.unsubscribe()
   })
 })


### PR DESCRIPTION
## Summary
- auth.js: noop unsubscribe 함수를 실제 호출하여 함수 커버리지 88.88% → 100%
- stac.js (line 95), catalog.js (line 190): 도달 불가능 방어 코드에 `/* v8 ignore next */` 추가로 브랜치 커버리지 100%
- 전체 커버리지: Stmts 100%, Branch 100%, Funcs 100%, Lines 100%

closes #192
closes #193

## Test plan
- [x] `npx vitest run --coverage` 전체 통과, 모든 메트릭 100%
- [x] 기존 236개 테스트 모두 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)