### PR TITLE
feat: 카탈로그 자동/수동 등록 출처 배지 및 필터 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -1221,6 +1221,23 @@
       font-size: 0.65rem;
     }
 
+    .catalog-source-badge {
+      display: inline-block;
+      padding: 0.1rem 0.35rem;
+      border-radius: 3px;
+      font-size: 0.6rem;
+      font-weight: 600;
+      vertical-align: middle;
+    }
+    .catalog-source-badge.stac {
+      background: #dbeafe;
+      color: #1d4ed8;
+    }
+    .catalog-source-badge.manual {
+      background: #f0fdf4;
+      color: #15803d;
+    }
+
     /* STAC Panel */
     .stac-toggle-btn {
       position: absolute;

--- a/src/catalog.js
+++ b/src/catalog.js
@@ -102,7 +102,7 @@ export async function saveCogImage(data) {
 /**
  * COG 영상 목록 조회
  */
-export async function getCogImages({ search = '', tag = '', sensor = '', region = '', sortBy = 'created_at', limit = 20, offset = 0 } = {}) {
+export async function getCogImages({ search = '', tag = '', sensor = '', region = '', sourceType = '', sortBy = 'created_at', limit = 20, offset = 0 } = {}) {
   if (!supabase) return { data: [], error: null }
 
   let query = supabase
@@ -126,6 +126,9 @@ export async function getCogImages({ search = '', tag = '', sensor = '', region 
   }
   if (region) {
     query = query.ilike('region', `%${region}%`)
+  }
+  if (sourceType) {
+    query = query.eq('source_type', sourceType)
   }
 
   const result = await query

--- a/src/catalogUI.js
+++ b/src/catalogUI.js
@@ -29,12 +29,18 @@ export function initCatalogUI(onSelectCog) {
     <input type="text" id="catalog-filter-tag" class="catalog-filter-input" placeholder="태그 필터 (예: flood)">
     <input type="text" id="catalog-filter-sensor" class="catalog-filter-input" placeholder="센서 필터">
     <input type="text" id="catalog-filter-region" class="catalog-filter-input" placeholder="지역 필터">
+    <select id="catalog-filter-source" class="catalog-filter-input" aria-label="등록 출처 필터">
+      <option value="">전체 출처</option>
+      <option value="manual">수동 등록</option>
+      <option value="stac">STAC 자동</option>
+    </select>
   `
   searchInput.parentNode.insertBefore(filterContainer, searchInput.nextSibling)
 
   const tagFilter = filterContainer.querySelector('#catalog-filter-tag')
   const sensorFilter = filterContainer.querySelector('#catalog-filter-sensor')
   const regionFilter = filterContainer.querySelector('#catalog-filter-region')
+  const sourceFilter = filterContainer.querySelector('#catalog-filter-source')
 
   // 정렬 드롭다운
   const sortContainer = document.createElement('div')
@@ -92,6 +98,7 @@ export function initCatalogUI(onSelectCog) {
   tagFilter.addEventListener('input', onFilterChange)
   sensorFilter.addEventListener('input', onFilterChange)
   regionFilter.addEventListener('input', onFilterChange)
+  sourceFilter.addEventListener('change', onFilterChange)
   sortSelect.addEventListener('change', () => {
     sortBy = sortSelect.value
     currentPage = 0
@@ -127,6 +134,7 @@ export function initCatalogUI(onSelectCog) {
       tag: tagFilter.value.trim(),
       sensor: sensorFilter.value.trim(),
       region: regionFilter.value.trim(),
+      sourceType: sourceFilter.value,
       sortBy,
       limit: PAGE_SIZE,
       offset
@@ -163,6 +171,10 @@ export function initCatalogUI(onSelectCog) {
         ? `<div class="catalog-card-tags">${item.tags.map(t => `<span class="catalog-tag">${escapeHtml(t)}</span>`).join('')}</div>`
         : ''
 
+      const sourceBadge = item.source_type === 'stac'
+        ? '<span class="catalog-source-badge stac">STAC</span>'
+        : '<span class="catalog-source-badge manual">수동</span>'
+
       const metaParts = [item.crs || '']
       if (item.sensor) metaParts.push(item.sensor)
       if (item.region) metaParts.push(item.region)
@@ -170,7 +182,7 @@ export function initCatalogUI(onSelectCog) {
 
       card.innerHTML = `
         ${thumbHtml}
-        <div class="catalog-card-title">${escapeHtml(item.title || '제목 없음')}</div>
+        <div class="catalog-card-title">${sourceBadge} ${escapeHtml(item.title || '제목 없음')}</div>
         <div class="catalog-card-desc">${escapeHtml(item.description || '')}</div>
         ${tagsHtml}
         <div class="catalog-card-meta">${metaParts.filter(Boolean).join(' | ')}</div>

--- a/tests/unit/catalog.test.js
+++ b/tests/unit/catalog.test.js
@@ -217,6 +217,20 @@ describe('getCogImages', () => {
     expect(q.ilike).toHaveBeenCalledWith('region', '%korea%')
   })
 
+  it('applies sourceType filter', async () => {
+    const q = createQueryMock([])
+    setMockQuery(q)
+    await getCogImages({ sourceType: 'stac' })
+    expect(q.eq).toHaveBeenCalledWith('source_type', 'stac')
+  })
+
+  it('does not apply sourceType filter when empty', async () => {
+    const q = createQueryMock([])
+    setMockQuery(q)
+    await getCogImages({ sourceType: '' })
+    expect(q.eq).not.toHaveBeenCalled()
+  })
+
   it('sorts by like_count client-side', async () => {
     const q = createQueryMock([
       { id: '1', likes: [{ count: 2 }] },


### PR DESCRIPTION
## Summary
- 카탈로그 카드에 STAC/수동 등록 출처 배지 표시 (파란색: STAC, 초록색: 수동)
- `getCogImages`에 `sourceType` 필터 파라미터 추가
- 카탈로그 패널에 등록 출처 필터 드롭다운 추가
- 단위 테스트 커버리지 100% 유지

closes #169

## Test plan
- [x] `sourceType` 필터가 Supabase 쿼리에 `eq('source_type', value)`로 적용되는지 단위 테스트 확인
- [x] 빈 `sourceType`일 때 필터가 적용되지 않는지 확인
- [x] 전체 커버리지 100% 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)