### PR TITLE
docs: getCogImages JSDoc sourceType 파라미터 추가 (Sprint 39)

### DIFF
--- a/src/catalog.js
+++ b/src/catalog.js
@@ -101,6 +101,15 @@ export async function saveCogImage(data) {
 
 /**
  * COG 영상 목록 조회
+ * @param {object} [options]
+ * @param {string} [options.search] - 제목/설명 키워드 검색
+ * @param {string} [options.tag] - 태그 필터
+ * @param {string} [options.sensor] - 센서 필터
+ * @param {string} [options.region] - 지역 필터
+ * @param {string} [options.sourceType] - 등록 출처 필터 ('stac' 또는 'manual', 빈 문자열이면 전체)
+ * @param {string} [options.sortBy] - 정렬 기준 ('created_at' 또는 'like_count')
+ * @param {number} [options.limit] - 페이지당 결과 수
+ * @param {number} [options.offset] - 페이지네이션 오프셋
  */
 export async function getCogImages({ search = '', tag = '', sensor = '', region = '', sourceType = '', sortBy = 'created_at', limit = 20, offset = 0 } = {}) {
   if (!supabase) return { data: [], error: null }


### PR DESCRIPTION
## Summary
- `getCogImages` 함수 JSDoc에 `sourceType` 파라미터 설명 누락 보완
- PR #195에서 추가된 등록 출처 필터 파라미터에 대한 문서화

## Test plan
- [ ] `src/catalog.js` JSDoc 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)