### PR TITLE
feat: 카탈로그 등록 이미지 삭제 UI 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -1005,6 +1005,27 @@
       color: #667eea;
     }
 
+    .catalog-delete-btn {
+      padding: 0.2rem 0.5rem;
+      border: 1px solid #fca5a5;
+      border-radius: 4px;
+      background: transparent;
+      color: #dc2626;
+      font-size: 0.75rem;
+      cursor: pointer;
+      transition: background 0.15s, border-color 0.15s;
+    }
+
+    .catalog-delete-btn:hover {
+      background: #fef2f2;
+      border-color: #dc2626;
+    }
+
+    .catalog-delete-btn:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
     /* Watchlist Panel */
     .watchlist-toggle-btn {
       position: absolute;

--- a/src/catalogUI.js
+++ b/src/catalogUI.js
@@ -1,5 +1,5 @@
 import { supabase } from './supabase.js'
-import { getCogImages } from './catalog.js'
+import { getCogImages, deleteCogImage } from './catalog.js'
 import { toggleLike, getLikeStates } from './likes.js'
 import { getSession } from './auth.js'
 
@@ -59,11 +59,16 @@ export function initCatalogUI(onSelectCog) {
   let sortBy = 'created_at'
   let debounceTimer = null
   let isUserLoggedIn = false
+  let currentUserId = null
 
-  getSession().then(session => { isUserLoggedIn = !!session?.user })
+  getSession().then(session => {
+    isUserLoggedIn = !!session?.user
+    currentUserId = session?.user?.id || null
+  })
   if (supabase) {
     supabase.auth.onAuthStateChange((_event, session) => {
       isUserLoggedIn = !!session?.user
+      currentUserId = session?.user?.id || null
     })
   }
 
@@ -222,6 +227,26 @@ export function initCatalogUI(onSelectCog) {
 
         actionsRow.appendChild(likeBtn)
         actionsRow.appendChild(watchlistBtn)
+
+        if (currentUserId && item.user_id === currentUserId) {
+          const deleteBtn = document.createElement('button')
+          deleteBtn.className = 'catalog-delete-btn'
+          deleteBtn.textContent = '삭제'
+          deleteBtn.addEventListener('click', async (e) => {
+            e.stopPropagation()
+            if (!confirm('이 영상을 삭제하시겠습니까?')) return
+            deleteBtn.disabled = true
+            const { error: delError } = await deleteCogImage(item.id)
+            if (delError) {
+              alert('삭제 실패: ' + delError.message)
+              deleteBtn.disabled = false
+              return
+            }
+            loadPage()
+          })
+          actionsRow.appendChild(deleteBtn)
+        }
+
         card.appendChild(actionsRow)
       } else {
         // 비로그인: 좋아요 수만 표시

--- a/tests/unit/catalogUI.test.js
+++ b/tests/unit/catalogUI.test.js
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const {
+  mockGetCogImages, mockDeleteCogImage, mockToggleLike, mockGetLikeStates,
+  mockGetSession, mockOnAuthStateChange, mockSupabase,
+} = vi.hoisted(() => {
+  const mockOnAuthStateChange = vi.fn()
+  return {
+    mockGetCogImages: vi.fn(),
+    mockDeleteCogImage: vi.fn(),
+    mockToggleLike: vi.fn(),
+    mockGetLikeStates: vi.fn(),
+    mockGetSession: vi.fn(),
+    mockOnAuthStateChange,
+    mockSupabase: { auth: { onAuthStateChange: mockOnAuthStateChange } },
+  }
+})
+
+vi.mock('../../src/supabase.js', () => ({ supabase: mockSupabase }))
+vi.mock('../../src/catalog.js', () => ({
+  getCogImages: mockGetCogImages,
+  deleteCogImage: mockDeleteCogImage,
+}))
+vi.mock('../../src/likes.js', () => ({
+  toggleLike: mockToggleLike,
+  getLikeStates: mockGetLikeStates,
+}))
+vi.mock('../../src/auth.js', () => ({
+  getSession: mockGetSession,
+}))
+
+import { initCatalogUI } from '../../src/catalogUI.js'
+
+function setupDOM() {
+  document.body.innerHTML = `
+    <button id="catalog-toggle-btn" aria-expanded="false">카탈로그</button>
+    <div id="catalog-panel">
+      <button id="catalog-panel-close">닫기</button>
+      <input id="catalog-search" type="text">
+      <div id="catalog-list"></div>
+      <button id="catalog-prev">이전</button>
+      <button id="catalog-next">다음</button>
+      <span id="catalog-page-info"></span>
+    </div>
+  `
+}
+
+describe('catalogUI delete button', () => {
+  const TEST_USER_ID = 'user-123'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupDOM()
+    mockGetSession.mockResolvedValue({ user: { id: TEST_USER_ID } })
+    mockOnAuthStateChange.mockImplementation(() => {})
+    mockGetLikeStates.mockResolvedValue(new Map())
+  })
+
+  async function openPanelWithItems(items) {
+    mockGetCogImages.mockResolvedValue({ data: items, error: null })
+    const onSelect = vi.fn()
+    initCatalogUI(onSelect)
+    // Wait for getSession to resolve
+    await new Promise(r => setTimeout(r, 10))
+    // Open panel
+    document.getElementById('catalog-toggle-btn').click()
+    // Wait for loadPage
+    await new Promise(r => setTimeout(r, 10))
+    return onSelect
+  }
+
+  it('shows delete button only for owner items', async () => {
+    await openPanelWithItems([
+      { id: '1', user_id: TEST_USER_ID, title: 'My Image', tags: [], created_at: '2026-01-01' },
+      { id: '2', user_id: 'other-user', title: 'Other Image', tags: [], created_at: '2026-01-01' },
+    ])
+
+    const cards = document.querySelectorAll('.catalog-card')
+    expect(cards).toHaveLength(2)
+
+    expect(cards[0].querySelector('.catalog-delete-btn')).not.toBeNull()
+    expect(cards[1].querySelector('.catalog-delete-btn')).toBeNull()
+  })
+
+  it('calls deleteCogImage after confirm and refreshes list', async () => {
+    mockDeleteCogImage.mockResolvedValue({ error: null })
+    window.confirm = vi.fn().mockReturnValue(true)
+
+    await openPanelWithItems([
+      { id: '1', user_id: TEST_USER_ID, title: 'My Image', tags: [], created_at: '2026-01-01' },
+    ])
+
+    document.querySelector('.catalog-delete-btn').click()
+    await new Promise(r => setTimeout(r, 10))
+
+    expect(mockDeleteCogImage).toHaveBeenCalledWith('1')
+    expect(mockGetCogImages).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not delete when confirm is cancelled', async () => {
+    window.confirm = vi.fn().mockReturnValue(false)
+
+    await openPanelWithItems([
+      { id: '1', user_id: TEST_USER_ID, title: 'My Image', tags: [], created_at: '2026-01-01' },
+    ])
+
+    document.querySelector('.catalog-delete-btn').click()
+    await new Promise(r => setTimeout(r, 10))
+
+    expect(mockDeleteCogImage).not.toHaveBeenCalled()
+  })
+
+  it('shows alert on delete error', async () => {
+    mockDeleteCogImage.mockResolvedValue({ error: { message: '권한 없음' } })
+    window.confirm = vi.fn().mockReturnValue(true)
+    window.alert = vi.fn()
+
+    await openPanelWithItems([
+      { id: '1', user_id: TEST_USER_ID, title: 'My Image', tags: [], created_at: '2026-01-01' },
+    ])
+
+    document.querySelector('.catalog-delete-btn').click()
+    await new Promise(r => setTimeout(r, 10))
+
+    expect(window.alert).toHaveBeenCalledWith('삭제 실패: 권한 없음')
+  })
+
+  it('does not show delete button when not logged in', async () => {
+    mockGetSession.mockResolvedValue(null)
+    mockGetCogImages.mockResolvedValue({
+      data: [{ id: '1', user_id: TEST_USER_ID, title: 'Image', tags: [], created_at: '2026-01-01' }],
+      error: null,
+    })
+
+    initCatalogUI(vi.fn())
+    await new Promise(r => setTimeout(r, 10))
+    document.getElementById('catalog-toggle-btn').click()
+    await new Promise(r => setTimeout(r, 10))
+
+    expect(document.querySelector('.catalog-delete-btn')).toBeNull()
+  })
+})

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -17,7 +17,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html'],
-      include: ['src/catalog.js', 'src/stac.js', 'src/auth.js', 'src/proxy.js', 'src/tags.js', 'src/viewerControls.js', 'src/likes.js', 'src/watchlist.js'],
+      include: ['src/catalog.js', 'src/catalogUI.js', 'src/stac.js', 'src/auth.js', 'src/proxy.js', 'src/tags.js', 'src/viewerControls.js', 'src/likes.js', 'src/watchlist.js'],
     }
   }
 })


### PR DESCRIPTION
## Summary
- 카탈로그 카드에 소유자 본인 이미지에 대해서만 삭제 버튼 표시
- 삭제 확인 다이얼로그(confirm)로 실수 방지, 삭제 후 목록 자동 갱신
- 기존 `deleteCogImage(id)` 함수 활용 (RLS가 서버 사이드 소유자 체크)
- catalogUI 유닛 테스트 5개 추가, 삭제 버튼 CSS 스타일 추가

## Test plan
- [x] 로그인 사용자가 본인 이미지에서만 삭제 버튼 노출 확인
- [x] 삭제 확인 후 deleteCogImage 호출 및 목록 갱신 확인
- [x] confirm 취소 시 삭제 미실행 확인
- [x] 삭제 실패 시 alert 표시 확인
- [x] 비로그인 시 삭제 버튼 미노출 확인
- [ ] E2E: 실제 Supabase 환경에서 삭제 플로우 확인

closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)