### PR TITLE
feat: 카탈로그 등록 이미지 메타데이터 편집 UI 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -1005,6 +1005,91 @@
       color: #667eea;
     }
 
+    .catalog-edit-btn {
+      padding: 0.2rem 0.5rem;
+      border: 1px solid #93c5fd;
+      border-radius: 4px;
+      background: transparent;
+      color: #2563eb;
+      font-size: 0.75rem;
+      cursor: pointer;
+      transition: background 0.15s, border-color 0.15s;
+    }
+
+    .catalog-edit-btn:hover {
+      background: #eff6ff;
+      border-color: #2563eb;
+    }
+
+    .catalog-edit-overlay {
+      position: fixed;
+      top: 0; left: 0; right: 0; bottom: 0;
+      background: rgba(0,0,0,0.5);
+      z-index: 1000;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .catalog-edit-dialog {
+      background: white;
+      border-radius: 8px;
+      padding: 1.5rem;
+      width: 320px;
+      max-width: 90vw;
+      box-shadow: 0 4px 24px rgba(0,0,0,0.2);
+    }
+
+    .catalog-edit-dialog h3 {
+      margin: 0 0 1rem;
+      font-size: 1rem;
+    }
+
+    .catalog-edit-dialog label {
+      display: block;
+      font-size: 0.8rem;
+      color: #374151;
+      margin-bottom: 0.75rem;
+    }
+
+    .catalog-edit-dialog input,
+    .catalog-edit-dialog textarea {
+      display: block;
+      width: 100%;
+      margin-top: 0.25rem;
+      padding: 0.4rem 0.5rem;
+      border: 1px solid #d1d5db;
+      border-radius: 4px;
+      font-size: 0.85rem;
+      font-family: inherit;
+    }
+
+    .catalog-edit-actions {
+      display: flex;
+      gap: 0.5rem;
+      justify-content: flex-end;
+      margin-top: 1rem;
+    }
+
+    .catalog-edit-actions button {
+      padding: 0.4rem 1rem;
+      border-radius: 4px;
+      border: 1px solid #d1d5db;
+      cursor: pointer;
+      font-size: 0.85rem;
+    }
+
+    .catalog-edit-actions #edit-save {
+      background: #667eea;
+      color: white;
+      border-color: #667eea;
+    }
+
+    .catalog-edit-actions #edit-save:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
     .catalog-delete-btn {
       padding: 0.2rem 0.5rem;
       border: 1px solid #fca5a5;

--- a/src/catalog.js
+++ b/src/catalog.js
@@ -168,6 +168,20 @@ export async function getCogImage(id) {
 }
 
 /**
+ * COG 영상 메타데이터 수정 (RLS가 소유자 체크)
+ * @param {string} id - 영상 ID
+ * @param {object} data - 수정할 필드 (title, description)
+ */
+export async function updateCogImage(id, data) {
+  if (!supabase) return { error: { message: 'Supabase 미설정' } }
+
+  return supabase
+    .from('cog_images')
+    .update(data)
+    .eq('id', id)
+}
+
+/**
  * COG 영상 삭제 (RLS가 소유자 체크)
  */
 export async function deleteCogImage(id) {

--- a/src/catalogUI.js
+++ b/src/catalogUI.js
@@ -1,5 +1,5 @@
 import { supabase } from './supabase.js'
-import { getCogImages, deleteCogImage } from './catalog.js'
+import { getCogImages, deleteCogImage, updateCogImage } from './catalog.js'
 import { toggleLike, getLikeStates } from './likes.js'
 import { getSession } from './auth.js'
 
@@ -229,6 +229,15 @@ export function initCatalogUI(onSelectCog) {
         actionsRow.appendChild(watchlistBtn)
 
         if (currentUserId && item.user_id === currentUserId) {
+          const editBtn = document.createElement('button')
+          editBtn.className = 'catalog-edit-btn'
+          editBtn.textContent = '편집'
+          editBtn.addEventListener('click', (e) => {
+            e.stopPropagation()
+            showEditModal(item, loadPage)
+          })
+          actionsRow.appendChild(editBtn)
+
           const deleteBtn = document.createElement('button')
           deleteBtn.className = 'catalog-delete-btn'
           deleteBtn.textContent = '삭제'
@@ -282,4 +291,50 @@ function formatDate(iso) {
   if (!iso) return ''
   const d = new Date(iso)
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+function showEditModal(item, onSave) {
+  // 기존 모달 제거
+  const existing = document.getElementById('catalog-edit-modal')
+  if (existing) existing.remove()
+
+  const overlay = document.createElement('div')
+  overlay.id = 'catalog-edit-modal'
+  overlay.className = 'catalog-edit-overlay'
+  overlay.innerHTML = `
+    <div class="catalog-edit-dialog">
+      <h3>영상 정보 편집</h3>
+      <label>제목<input type="text" id="edit-title" value="${escapeAttr(item.title || '')}"></label>
+      <label>설명<textarea id="edit-description" rows="3">${escapeHtml(item.description || '')}</textarea></label>
+      <div class="catalog-edit-actions">
+        <button id="edit-cancel" type="button">취소</button>
+        <button id="edit-save" type="button">저장</button>
+      </div>
+    </div>
+  `
+  document.body.appendChild(overlay)
+
+  overlay.querySelector('#edit-cancel').addEventListener('click', () => overlay.remove())
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) overlay.remove()
+  })
+
+  overlay.querySelector('#edit-save').addEventListener('click', async () => {
+    const title = overlay.querySelector('#edit-title').value.trim()
+    const description = overlay.querySelector('#edit-description').value.trim()
+    const saveBtn = overlay.querySelector('#edit-save')
+    saveBtn.disabled = true
+    const { error } = await updateCogImage(item.id, { title: title || null, description: description || null })
+    if (error) {
+      alert('수정 실패: ' + error.message)
+      saveBtn.disabled = false
+      return
+    }
+    overlay.remove()
+    onSave()
+  })
+}
+
+function escapeAttr(str) {
+  return str.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 }

--- a/tests/unit/catalog.test.js
+++ b/tests/unit/catalog.test.js
@@ -7,6 +7,7 @@ const { mockSupabase, setMockQuery, createQueryMock, mockDetectBands } = vi.hois
     const chain = {
       select: vi.fn().mockReturnThis(),
       insert: vi.fn().mockReturnThis(),
+      update: vi.fn().mockReturnThis(),
       delete: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
       or: vi.fn().mockReturnThis(),
@@ -37,7 +38,7 @@ const { mockSupabase, setMockQuery, createQueryMock, mockDetectBands } = vi.hois
 vi.mock('../../src/supabase.js', () => ({ supabase: mockSupabase }))
 vi.mock('@conaonda/ol-cog-layers', () => ({ detectBands: mockDetectBands }))
 
-import { uploadThumbnail, generateTitleFromUrl, generateDescriptionFromMeta, saveCogImage, getCogImages, getCogImage, deleteCogImage, extractCogMetadata, generateThumbnail } from '../../src/catalog.js'
+import { uploadThumbnail, generateTitleFromUrl, generateDescriptionFromMeta, saveCogImage, getCogImages, getCogImage, updateCogImage, deleteCogImage, extractCogMetadata, generateThumbnail } from '../../src/catalog.js'
 
 describe('uploadThumbnail', () => {
   beforeEach(() => {
@@ -252,6 +253,17 @@ describe('getCogImage', () => {
   })
 })
 
+describe('updateCogImage', () => {
+  it('updates cog_image by id', async () => {
+    const q = createQueryMock(null)
+    setMockQuery(q)
+    await updateCogImage('123', { title: 'New', description: 'Desc' })
+    expect(mockSupabase.from).toHaveBeenCalledWith('cog_images')
+    expect(q.update).toHaveBeenCalledWith({ title: 'New', description: 'Desc' })
+    expect(q.eq).toHaveBeenCalledWith('id', '123')
+  })
+})
+
 describe('deleteCogImage', () => {
   it('deletes cog_image by id', async () => {
     const q = createQueryMock(null)
@@ -434,6 +446,11 @@ describe('supabase null guards', () => {
   it('getCogImage returns null data', async () => {
     const result = await nullMod.getCogImage('123')
     expect(result).toEqual({ data: null, error: null })
+  })
+
+  it('updateCogImage returns error', async () => {
+    const result = await nullMod.updateCogImage('123', { title: 'x' })
+    expect(result.error.message).toBe('Supabase 미설정')
   })
 
   it('deleteCogImage returns error', async () => {

--- a/tests/unit/catalogUI.test.js
+++ b/tests/unit/catalogUI.test.js
@@ -2,13 +2,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const {
-  mockGetCogImages, mockDeleteCogImage, mockToggleLike, mockGetLikeStates,
+  mockGetCogImages, mockDeleteCogImage, mockUpdateCogImage, mockToggleLike, mockGetLikeStates,
   mockGetSession, mockOnAuthStateChange, mockSupabase,
 } = vi.hoisted(() => {
   const mockOnAuthStateChange = vi.fn()
   return {
     mockGetCogImages: vi.fn(),
     mockDeleteCogImage: vi.fn(),
+    mockUpdateCogImage: vi.fn(),
     mockToggleLike: vi.fn(),
     mockGetLikeStates: vi.fn(),
     mockGetSession: vi.fn(),
@@ -21,6 +22,7 @@ vi.mock('../../src/supabase.js', () => ({ supabase: mockSupabase }))
 vi.mock('../../src/catalog.js', () => ({
   getCogImages: mockGetCogImages,
   deleteCogImage: mockDeleteCogImage,
+  updateCogImage: mockUpdateCogImage,
 }))
 vi.mock('../../src/likes.js', () => ({
   toggleLike: mockToggleLike,
@@ -124,6 +126,84 @@ describe('catalogUI delete button', () => {
     await new Promise(r => setTimeout(r, 10))
 
     expect(window.alert).toHaveBeenCalledWith('삭제 실패: 권한 없음')
+  })
+
+  it('shows edit button only for owner items', async () => {
+    await openPanelWithItems([
+      { id: '1', user_id: TEST_USER_ID, title: 'My Image', tags: [], created_at: '2026-01-01' },
+      { id: '2', user_id: 'other-user', title: 'Other Image', tags: [], created_at: '2026-01-01' },
+    ])
+
+    const cards = document.querySelectorAll('.catalog-card')
+    expect(cards[0].querySelector('.catalog-edit-btn')).not.toBeNull()
+    expect(cards[1].querySelector('.catalog-edit-btn')).toBeNull()
+  })
+
+  it('opens edit modal and saves successfully', async () => {
+    mockUpdateCogImage.mockResolvedValue({ error: null })
+
+    await openPanelWithItems([
+      { id: '1', user_id: TEST_USER_ID, title: 'Old Title', description: 'Old Desc', tags: [], created_at: '2026-01-01' },
+    ])
+
+    document.querySelector('.catalog-edit-btn').click()
+    await new Promise(r => setTimeout(r, 10))
+
+    const modal = document.getElementById('catalog-edit-modal')
+    expect(modal).not.toBeNull()
+
+    modal.querySelector('#edit-title').value = 'New Title'
+    modal.querySelector('#edit-description').value = 'New Desc'
+    modal.querySelector('#edit-save').click()
+    await new Promise(r => setTimeout(r, 10))
+
+    expect(mockUpdateCogImage).toHaveBeenCalledWith('1', { title: 'New Title', description: 'New Desc' })
+    expect(document.getElementById('catalog-edit-modal')).toBeNull()
+    expect(mockGetCogImages).toHaveBeenCalledTimes(2)
+  })
+
+  it('shows alert on edit save error', async () => {
+    mockUpdateCogImage.mockResolvedValue({ error: { message: '수정 실패' } })
+    window.alert = vi.fn()
+
+    await openPanelWithItems([
+      { id: '1', user_id: TEST_USER_ID, title: 'Title', tags: [], created_at: '2026-01-01' },
+    ])
+
+    document.querySelector('.catalog-edit-btn').click()
+    await new Promise(r => setTimeout(r, 10))
+
+    document.querySelector('#edit-save').click()
+    await new Promise(r => setTimeout(r, 10))
+
+    expect(window.alert).toHaveBeenCalledWith('수정 실패: 수정 실패')
+    expect(document.getElementById('catalog-edit-modal')).not.toBeNull()
+  })
+
+  it('closes edit modal on cancel button', async () => {
+    await openPanelWithItems([
+      { id: '1', user_id: TEST_USER_ID, title: 'Title', tags: [], created_at: '2026-01-01' },
+    ])
+
+    document.querySelector('.catalog-edit-btn').click()
+    await new Promise(r => setTimeout(r, 10))
+    expect(document.getElementById('catalog-edit-modal')).not.toBeNull()
+
+    document.querySelector('#edit-cancel').click()
+    expect(document.getElementById('catalog-edit-modal')).toBeNull()
+  })
+
+  it('closes edit modal on overlay click', async () => {
+    await openPanelWithItems([
+      { id: '1', user_id: TEST_USER_ID, title: 'Title', tags: [], created_at: '2026-01-01' },
+    ])
+
+    document.querySelector('.catalog-edit-btn').click()
+    await new Promise(r => setTimeout(r, 10))
+
+    const overlay = document.getElementById('catalog-edit-modal')
+    overlay.click()
+    expect(document.getElementById('catalog-edit-modal')).toBeNull()
   })
 
   it('does not show delete button when not logged in', async () => {


### PR DESCRIPTION
## Summary
- `catalog.js`에 `updateCogImage(id, data)` 함수 추가 (Supabase update)
- `catalogUI.js`에 소유자 전용 편집 버튼 및 편집 모달 UI 추가
- 제목/설명 수정 후 카드 목록 즉시 갱신
- 유닛 테스트 8개 추가 (updateCogImage + 편집 UI 모달 플로우)

## Test plan
- [x] 250개 전체 테스트 통과
- [x] `updateCogImage` 정상 호출 및 null supabase 에러 테스트
- [x] 편집 버튼 소유자 전용 표시 확인
- [x] 모달 열기/저장/취소/오버레이 클릭 닫기 테스트
- [x] 저장 에러 시 alert 표시 테스트

closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)