### PR TITLE
feat: 카탈로그 카드 공유 URL 복사 버튼 추가

### DIFF
--- a/src/catalogUI.js
+++ b/src/catalogUI.js
@@ -268,6 +268,24 @@ export function initCatalogUI(onSelectCog) {
         }
       }
 
+      // 공유 버튼 (모든 사용자에게 표시)
+      const shareBtn = document.createElement('button')
+      shareBtn.className = 'catalog-share-btn'
+      shareBtn.textContent = '🔗 공유'
+      shareBtn.addEventListener('click', async (e) => {
+        e.stopPropagation()
+        const shareUrl = `${location.origin}${location.pathname}?url=${encodeURIComponent(item.url)}`
+        try {
+          await navigator.clipboard.writeText(shareUrl)
+          shareBtn.textContent = '✅ 복사됨'
+          setTimeout(() => { shareBtn.textContent = '🔗 공유' }, 2000)
+        } catch {
+          shareBtn.textContent = '❌ 실패'
+          setTimeout(() => { shareBtn.textContent = '🔗 공유' }, 2000)
+        }
+      })
+      card.appendChild(shareBtn)
+
       card.addEventListener('click', () => {
         panel.classList.remove('open')
         onSelectCog(item.url, item)

--- a/tests/unit/catalogUI.test.js
+++ b/tests/unit/catalogUI.test.js
@@ -598,6 +598,56 @@ describe('catalogUI interactions', () => {
     expect(() => initCatalogUI(vi.fn())).not.toThrow()
   })
 
+  it('share button copies URL to clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+
+    await initAndOpen([{ id: '1', url: 'http://example.com/cog.tif', title: 'T', tags: [], created_at: '2026-01-01' }])
+
+    const shareBtn = document.querySelector('.catalog-share-btn')
+    expect(shareBtn).not.toBeNull()
+    expect(shareBtn.textContent).toBe('🔗 공유')
+
+    shareBtn.click()
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('?url=http%3A%2F%2Fexample.com%2Fcog.tif'))
+    expect(shareBtn.textContent).toBe('✅ 복사됨')
+
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(shareBtn.textContent).toBe('🔗 공유')
+  })
+
+  it('share button shows failure when clipboard fails', async () => {
+    Object.assign(navigator, { clipboard: { writeText: vi.fn().mockRejectedValue(new Error('denied')) } })
+
+    await initAndOpen([{ id: '1', url: 'http://example.com/cog.tif', title: 'T', tags: [], created_at: '2026-01-01' }])
+
+    const shareBtn = document.querySelector('.catalog-share-btn')
+    shareBtn.click()
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(shareBtn.textContent).toBe('❌ 실패')
+
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(shareBtn.textContent).toBe('🔗 공유')
+  })
+
+  it('share button is shown for non-logged-in users', async () => {
+    mockGetSession.mockResolvedValue(null)
+    mockGetCogImages.mockResolvedValue({
+      data: [{ id: '1', url: 'http://example.com/cog.tif', title: 'T', tags: [], created_at: '2026-01-01' }],
+      error: null,
+    })
+
+    initCatalogUI(vi.fn())
+    await vi.advanceTimersByTimeAsync(10)
+    document.getElementById('catalog-toggle-btn').click()
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(document.querySelector('.catalog-share-btn')).not.toBeNull()
+  })
+
   it('like button handles NaN count gracefully', async () => {
     mockToggleLike.mockResolvedValue({ liked: true, error: null })
     mockGetLikeStates.mockResolvedValue(new Map([['1', { count: 0, liked: false }]]))


### PR DESCRIPTION
## Summary
- 카탈로그 카드에 🔗 공유 버튼 추가 (로그인 여부 무관, 모든 사용자에게 표시)
- 클릭 시 `?url=<cog_url>` 형식의 뷰어 URL을 클립보드에 복사
- 복사 성공(✅ 복사됨) / 실패(❌ 실패) 피드백 2초간 표시 후 원래 텍스트로 복구

## Test plan
- [x] 공유 버튼 클립보드 복사 성공 테스트
- [x] 클립보드 실패 시 에러 피드백 테스트
- [x] 비로그인 사용자에게도 공유 버튼 표시 테스트
- [x] 전체 287개 테스트 통과 확인

closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)