### PR TITLE
feat: 카탈로그 패널에 내 등록 영상만 보기 필터 추가

### DIFF
--- a/src/catalog.js
+++ b/src/catalog.js
@@ -108,10 +108,11 @@ export async function saveCogImage(data) {
  * @param {string} [options.region] - 지역 필터
  * @param {string} [options.sourceType] - 등록 출처 필터 ('stac' 또는 'manual', 빈 문자열이면 전체)
  * @param {string} [options.sortBy] - 정렬 기준 ('created_at' 또는 'like_count')
+ * @param {string} [options.userId] - 특정 사용자의 영상만 필터 (user_id 기준)
  * @param {number} [options.limit] - 페이지당 결과 수
  * @param {number} [options.offset] - 페이지네이션 오프셋
  */
-export async function getCogImages({ search = '', tag = '', sensor = '', region = '', sourceType = '', sortBy = 'created_at', limit = 20, offset = 0 } = {}) {
+export async function getCogImages({ search = '', tag = '', sensor = '', region = '', sourceType = '', sortBy = 'created_at', userId = '', limit = 20, offset = 0 } = {}) {
   if (!supabase) return { data: [], error: null }
 
   let query = supabase
@@ -138,6 +139,9 @@ export async function getCogImages({ search = '', tag = '', sensor = '', region 
   }
   if (sourceType) {
     query = query.eq('source_type', sourceType)
+  }
+  if (userId) {
+    query = query.eq('user_id', userId)
   }
 
   const result = await query

--- a/src/catalogUI.js
+++ b/src/catalogUI.js
@@ -42,6 +42,16 @@ export function initCatalogUI(onSelectCog) {
   const regionFilter = filterContainer.querySelector('#catalog-filter-region')
   const sourceFilter = filterContainer.querySelector('#catalog-filter-source')
 
+  // 내 영상 필터 (로그인 시에만 표시)
+  const onlyMineContainer = document.createElement('div')
+  onlyMineContainer.className = 'catalog-only-mine'
+  onlyMineContainer.style.display = 'none'
+  onlyMineContainer.innerHTML = `
+    <label><input type="checkbox" id="catalog-filter-only-mine"> 내 등록 영상만</label>
+  `
+  filterContainer.parentNode.insertBefore(onlyMineContainer, filterContainer.nextSibling)
+  const onlyMineCheckbox = onlyMineContainer.querySelector('#catalog-filter-only-mine')
+
   // 정렬 드롭다운
   const sortContainer = document.createElement('div')
   sortContainer.className = 'catalog-sort'
@@ -51,7 +61,7 @@ export function initCatalogUI(onSelectCog) {
       <option value="like_count">인기순</option>
     </select>
   `
-  filterContainer.parentNode.insertBefore(sortContainer, filterContainer.nextSibling)
+  onlyMineContainer.parentNode.insertBefore(sortContainer, onlyMineContainer.nextSibling)
   const sortSelect = sortContainer.querySelector('#catalog-sort-select')
 
   let currentPage = 0
@@ -61,14 +71,19 @@ export function initCatalogUI(onSelectCog) {
   let isUserLoggedIn = false
   let currentUserId = null
 
-  getSession().then(session => {
+  function updateLoginState(session) {
     isUserLoggedIn = !!session?.user
     currentUserId = session?.user?.id || null
-  })
+    onlyMineContainer.style.display = isUserLoggedIn ? '' : 'none'
+    if (!isUserLoggedIn) {
+      onlyMineCheckbox.checked = false
+    }
+  }
+
+  getSession().then(updateLoginState)
   if (supabase) {
     supabase.auth.onAuthStateChange((_event, session) => {
-      isUserLoggedIn = !!session?.user
-      currentUserId = session?.user?.id || null
+      updateLoginState(session)
     })
   }
 
@@ -109,6 +124,10 @@ export function initCatalogUI(onSelectCog) {
     currentPage = 0
     loadPage()
   })
+  onlyMineCheckbox.addEventListener('change', () => {
+    currentPage = 0
+    loadPage()
+  })
 
   prevBtn.addEventListener('click', () => {
     if (currentPage > 0) {
@@ -141,6 +160,7 @@ export function initCatalogUI(onSelectCog) {
       region: regionFilter.value.trim(),
       sourceType: sourceFilter.value,
       sortBy,
+      userId: onlyMineCheckbox.checked ? currentUserId : '',
       limit: PAGE_SIZE,
       offset
     })

--- a/supabase/migrations/00005_add_user_id_to_cog_images.sql
+++ b/supabase/migrations/00005_add_user_id_to_cog_images.sql
@@ -1,0 +1,24 @@
+-- ============================================
+-- cog_images 테이블에 user_id 컬럼 추가
+-- 등록자 기반 필터링 및 소유자 확인용
+-- ============================================
+
+-- user_id 컬럼 추가 (기존 데이터는 NULL 허용)
+ALTER TABLE public.cog_images
+  ADD COLUMN user_id uuid REFERENCES public.profiles(id) ON DELETE SET NULL;
+
+-- INSERT 시 auth.uid() 자동 설정
+ALTER TABLE public.cog_images
+  ALTER COLUMN user_id SET DEFAULT auth.uid();
+
+-- 인덱스 추가
+CREATE INDEX idx_cog_images_user_id ON public.cog_images(user_id);
+
+-- UPDATE/DELETE RLS 정책 (소유자만 가능)
+CREATE POLICY "Owner can update own COG images"
+  ON public.cog_images FOR UPDATE
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Owner can delete own COG images"
+  ON public.cog_images FOR DELETE
+  USING (auth.uid() = user_id);

--- a/tests/unit/catalog.test.js
+++ b/tests/unit/catalog.test.js
@@ -232,6 +232,20 @@ describe('getCogImages', () => {
     expect(q.eq).not.toHaveBeenCalled()
   })
 
+  it('applies userId filter', async () => {
+    const q = createQueryMock([])
+    setMockQuery(q)
+    await getCogImages({ userId: 'user-123' })
+    expect(q.eq).toHaveBeenCalledWith('user_id', 'user-123')
+  })
+
+  it('does not apply userId filter when empty', async () => {
+    const q = createQueryMock([])
+    setMockQuery(q)
+    await getCogImages({ userId: '' })
+    expect(q.eq).not.toHaveBeenCalled()
+  })
+
   it('sorts by like_count client-side', async () => {
     const q = createQueryMock([
       { id: '1', likes: [{ count: 2 }] },

--- a/tests/unit/catalogUI.test.js
+++ b/tests/unit/catalogUI.test.js
@@ -648,6 +648,65 @@ describe('catalogUI interactions', () => {
     expect(document.querySelector('.catalog-share-btn')).not.toBeNull()
   })
 
+  it('shows only-mine checkbox when logged in', async () => {
+    await initAndOpen([{ id: '1', title: 'T', tags: [], created_at: '2026-01-01' }])
+
+    const onlyMineContainer = document.querySelector('.catalog-only-mine')
+    expect(onlyMineContainer).not.toBeNull()
+    expect(onlyMineContainer.style.display).toBe('')
+  })
+
+  it('hides only-mine checkbox when not logged in', async () => {
+    mockGetSession.mockResolvedValue(null)
+    mockGetCogImages.mockResolvedValue({ data: [], error: null })
+
+    initCatalogUI(vi.fn())
+    await vi.advanceTimersByTimeAsync(10)
+
+    const onlyMineContainer = document.querySelector('.catalog-only-mine')
+    expect(onlyMineContainer.style.display).toBe('none')
+  })
+
+  it('only-mine checkbox passes userId to getCogImages', async () => {
+    await initAndOpen([{ id: '1', title: 'T', tags: [], created_at: '2026-01-01' }])
+    mockGetCogImages.mockClear()
+    mockGetCogImages.mockResolvedValue({ data: [], error: null })
+
+    const checkbox = document.getElementById('catalog-filter-only-mine')
+    checkbox.checked = true
+    checkbox.dispatchEvent(new Event('change'))
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(mockGetCogImages).toHaveBeenCalledWith(expect.objectContaining({ userId: TEST_USER_ID }))
+  })
+
+  it('unchecking only-mine checkbox passes empty userId', async () => {
+    await initAndOpen([{ id: '1', title: 'T', tags: [], created_at: '2026-01-01' }])
+    mockGetCogImages.mockClear()
+    mockGetCogImages.mockResolvedValue({ data: [], error: null })
+
+    const checkbox = document.getElementById('catalog-filter-only-mine')
+    checkbox.checked = false
+    checkbox.dispatchEvent(new Event('change'))
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(mockGetCogImages).toHaveBeenCalledWith(expect.objectContaining({ userId: '' }))
+  })
+
+  it('hides only-mine checkbox and unchecks on logout', async () => {
+    await initAndOpen([{ id: '1', title: 'T', tags: [], created_at: '2026-01-01' }])
+
+    const checkbox = document.getElementById('catalog-filter-only-mine')
+    checkbox.checked = true
+
+    const authCallback = mockOnAuthStateChange.mock.calls[0][0]
+    authCallback('SIGNED_OUT', null)
+
+    const onlyMineContainer = document.querySelector('.catalog-only-mine')
+    expect(onlyMineContainer.style.display).toBe('none')
+    expect(checkbox.checked).toBe(false)
+  })
+
   it('like button handles NaN count gracefully', async () => {
     mockToggleLike.mockResolvedValue({ liked: true, error: null })
     mockGetLikeStates.mockResolvedValue(new Map([['1', { count: 0, liked: false }]]))


### PR DESCRIPTION
## Summary
- `cog_images` 테이블에 `user_id` 컬럼 추가 (마이그레이션 00005, INSERT 시 `auth.uid()` 자동 설정)
- `getCogImages`에 `userId` 파라미터 추가하여 특정 사용자의 영상만 필터링 가능
- catalogUI에 '내 등록 영상만' 체크박스 추가 (비로그인 시 숨김, 로그아웃 시 자동 해제)
- UPDATE/DELETE RLS 정책 추가 (소유자만 수정/삭제 가능)

## Test plan
- [x] 단위 테스트 7개 추가 (catalog: userId 필터 2개, catalogUI: 체크박스 5개)
- [x] 전체 294개 테스트 통과
- [ ] 로그인 후 '내 영상' 체크박스 체크 → 내가 등록한 영상만 표시
- [ ] 비로그인 상태에서 체크박스 숨김 확인
- [ ] 기존 검색/출처/정렬 필터와 조합 동작 확인
- [ ] 마이그레이션 적용 후 기존 데이터 영향 없음 확인

closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)