### PR TITLE
feat: 카탈로그 영상 조회수(view count) 기록 및 카드 표시

### DIFF
--- a/src/catalog.js
+++ b/src/catalog.js
@@ -186,6 +186,17 @@ export async function updateCogImage(id, data) {
 }
 
 /**
+ * COG 영상 조회수 1 증가 (비로그인 사용자도 호출 가능)
+ * @param {string} id - 영상 ID
+ */
+export async function incrementViewCount(id) {
+  if (!supabase) return { error: { message: 'Supabase 미설정' } }
+
+  const { error } = await supabase.rpc('increment_view_count', { image_id: id })
+  return { error: error || null }
+}
+
+/**
  * COG 영상 삭제 (RLS가 소유자 체크)
  */
 export async function deleteCogImage(id) {

--- a/src/catalogUI.js
+++ b/src/catalogUI.js
@@ -1,5 +1,5 @@
 import { supabase } from './supabase.js'
-import { getCogImages, deleteCogImage, updateCogImage } from './catalog.js'
+import { getCogImages, deleteCogImage, updateCogImage, incrementViewCount } from './catalog.js'
 import { toggleLike, getLikeStates } from './likes.js'
 import { getSession } from './auth.js'
 
@@ -306,8 +306,15 @@ export function initCatalogUI(onSelectCog) {
       })
       card.appendChild(shareBtn)
 
+      // 조회수 표시
+      const viewCountEl = document.createElement('span')
+      viewCountEl.className = 'catalog-view-count'
+      viewCountEl.textContent = `👁 ${item.view_count || 0}`
+      card.appendChild(viewCountEl)
+
       card.addEventListener('click', () => {
         panel.classList.remove('open')
+        incrementViewCount(item.id)
         onSelectCog(item.url, item)
       })
       listEl.appendChild(card)

--- a/supabase/migrations/00006_add_view_count.sql
+++ b/supabase/migrations/00006_add_view_count.sql
@@ -1,0 +1,19 @@
+-- ============================================
+-- cog_images 테이블에 view_count 컬럼 추가
+-- 카탈로그 영상 조회수 기록용
+-- ============================================
+
+-- view_count 컬럼 추가
+ALTER TABLE public.cog_images
+  ADD COLUMN view_count integer DEFAULT 0 NOT NULL;
+
+-- RPC 함수: 조회수 1 증가 (비로그인 사용자도 호출 가능)
+CREATE OR REPLACE FUNCTION public.increment_view_count(image_id uuid)
+RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+AS $$
+  UPDATE public.cog_images
+  SET view_count = view_count + 1
+  WHERE id = image_id;
+$$;

--- a/tests/unit/catalog.test.js
+++ b/tests/unit/catalog.test.js
@@ -38,7 +38,7 @@ const { mockSupabase, setMockQuery, createQueryMock, mockDetectBands } = vi.hois
 vi.mock('../../src/supabase.js', () => ({ supabase: mockSupabase }))
 vi.mock('@conaonda/ol-cog-layers', () => ({ detectBands: mockDetectBands }))
 
-import { uploadThumbnail, generateTitleFromUrl, generateDescriptionFromMeta, saveCogImage, getCogImages, getCogImage, updateCogImage, deleteCogImage, extractCogMetadata, generateThumbnail } from '../../src/catalog.js'
+import { uploadThumbnail, generateTitleFromUrl, generateDescriptionFromMeta, saveCogImage, getCogImages, getCogImage, updateCogImage, deleteCogImage, incrementViewCount, extractCogMetadata, generateThumbnail } from '../../src/catalog.js'
 
 describe('uploadThumbnail', () => {
   beforeEach(() => {
@@ -278,6 +278,21 @@ describe('updateCogImage', () => {
   })
 })
 
+describe('incrementViewCount', () => {
+  it('calls rpc to increment view count', async () => {
+    mockSupabase.rpc = vi.fn().mockResolvedValue({ error: null })
+    const result = await incrementViewCount('img-1')
+    expect(mockSupabase.rpc).toHaveBeenCalledWith('increment_view_count', { image_id: 'img-1' })
+    expect(result.error).toBeNull()
+  })
+
+  it('returns error on rpc failure', async () => {
+    mockSupabase.rpc = vi.fn().mockResolvedValue({ error: { message: 'fail' } })
+    const result = await incrementViewCount('img-1')
+    expect(result.error.message).toBe('fail')
+  })
+})
+
 describe('deleteCogImage', () => {
   it('deletes cog_image by id', async () => {
     const q = createQueryMock(null)
@@ -469,6 +484,11 @@ describe('supabase null guards', () => {
 
   it('deleteCogImage returns error', async () => {
     const result = await nullMod.deleteCogImage('123')
+    expect(result.error.message).toBe('Supabase 미설정')
+  })
+
+  it('incrementViewCount returns error', async () => {
+    const result = await nullMod.incrementViewCount('123')
     expect(result.error.message).toBe('Supabase 미설정')
   })
 })

--- a/tests/unit/catalogUI.test.js
+++ b/tests/unit/catalogUI.test.js
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 const {
-  mockGetCogImages, mockDeleteCogImage, mockUpdateCogImage, mockToggleLike, mockGetLikeStates,
+  mockGetCogImages, mockDeleteCogImage, mockUpdateCogImage, mockIncrementViewCount, mockToggleLike, mockGetLikeStates,
   mockGetSession, mockOnAuthStateChange, mockSupabase,
 } = vi.hoisted(() => {
   const mockOnAuthStateChange = vi.fn()
@@ -10,6 +10,7 @@ const {
     mockGetCogImages: vi.fn(),
     mockDeleteCogImage: vi.fn(),
     mockUpdateCogImage: vi.fn(),
+    mockIncrementViewCount: vi.fn().mockResolvedValue({ error: null }),
     mockToggleLike: vi.fn(),
     mockGetLikeStates: vi.fn(),
     mockGetSession: vi.fn(),
@@ -23,6 +24,7 @@ vi.mock('../../src/catalog.js', () => ({
   getCogImages: mockGetCogImages,
   deleteCogImage: mockDeleteCogImage,
   updateCogImage: mockUpdateCogImage,
+  incrementViewCount: mockIncrementViewCount,
 }))
 vi.mock('../../src/likes.js', () => ({
   toggleLike: mockToggleLike,
@@ -436,7 +438,7 @@ describe('catalogUI interactions', () => {
     expect(cards[0].textContent).toContain('♥ 10')
   })
 
-  it('card click closes panel and calls onSelectCog', async () => {
+  it('card click closes panel, calls onSelectCog and incrementViewCount', async () => {
     const onSelect = vi.fn()
     const item = { id: '1', url: 'http://example.com/cog.tif', title: 'T', tags: [], created_at: '2026-01-01' }
     await initAndOpen([item], onSelect)
@@ -445,6 +447,22 @@ describe('catalogUI interactions', () => {
 
     expect(document.getElementById('catalog-panel').classList.contains('open')).toBe(false)
     expect(onSelect).toHaveBeenCalledWith('http://example.com/cog.tif', expect.objectContaining({ id: '1' }))
+    expect(mockIncrementViewCount).toHaveBeenCalledWith('1')
+  })
+
+  it('renders view count on card', async () => {
+    await initAndOpen([{ id: '1', title: 'T', tags: [], created_at: '2026-01-01', view_count: 42 }])
+
+    const viewCount = document.querySelector('.catalog-view-count')
+    expect(viewCount).not.toBeNull()
+    expect(viewCount.textContent).toBe('👁 42')
+  })
+
+  it('renders view count as 0 when missing', async () => {
+    await initAndOpen([{ id: '1', title: 'T', tags: [], created_at: '2026-01-01' }])
+
+    const viewCount = document.querySelector('.catalog-view-count')
+    expect(viewCount.textContent).toBe('👁 0')
   })
 
   it('renders thumbnail when thumbnail_url exists', async () => {


### PR DESCRIPTION
## Summary
- `cog_images` 테이블에 `view_count` 컬럼 및 `increment_view_count` RPC 함수 추가 (마이그레이션 00006)
- `catalog.js`에 `incrementViewCount()` 함수 추가
- 카탈로그 카드 클릭(뷰어 로드) 시 조회수 자동 증가, 카드에 👁 N 형태로 표시

closes #213

## Test plan
- [x] 단위 테스트: `incrementViewCount` 함수 (성공/실패/null guard)
- [x] 단위 테스트: 카드 렌더링에 `view_count` 표시 확인
- [x] 단위 테스트: 카드 클릭 시 `incrementViewCount` 호출 확인
- [x] 전체 테스트 299개 통과, Stmts/Funcs/Lines 100%, Branch 99.54%

🤖 Generated with [Claude Code](https://claude.com/claude-code)