### PR TITLE
feat: 카탈로그 필터 일괄 초기화 버튼 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -1301,6 +1301,20 @@
       border-color: #667eea;
     }
 
+    .catalog-filter-reset-btn {
+      padding: 0.3rem 0.6rem;
+      border: 1px solid #e5e7eb;
+      border-radius: 4px;
+      font-size: 0.75rem;
+      background: #f3f4f6;
+      color: #374151;
+      cursor: pointer;
+    }
+
+    .catalog-filter-reset-btn:hover {
+      background: #e5e7eb;
+    }
+
     /* Catalog card thumbnail */
     .catalog-card-thumb {
       width: 100%;

--- a/src/catalogUI.js
+++ b/src/catalogUI.js
@@ -42,6 +42,14 @@ export function initCatalogUI(onSelectCog) {
   const regionFilter = filterContainer.querySelector('#catalog-filter-region')
   const sourceFilter = filterContainer.querySelector('#catalog-filter-source')
 
+  // 필터 초기화 버튼
+  const resetBtn = document.createElement('button')
+  resetBtn.id = 'catalog-filter-reset'
+  resetBtn.className = 'catalog-filter-reset-btn'
+  resetBtn.textContent = '필터 초기화'
+  resetBtn.style.display = 'none'
+  filterContainer.appendChild(resetBtn)
+
   // 내 영상 필터 (로그인 시에만 표시)
   const onlyMineContainer = document.createElement('div')
   onlyMineContainer.className = 'catalog-only-mine'
@@ -106,11 +114,38 @@ export function initCatalogUI(onSelectCog) {
     })
   }
 
+  function hasActiveFilter() {
+    return searchInput.value.trim() !== '' ||
+      tagFilter.value.trim() !== '' ||
+      sensorFilter.value.trim() !== '' ||
+      regionFilter.value.trim() !== '' ||
+      sourceFilter.value !== '' ||
+      onlyMineCheckbox.checked
+  }
+
+  function updateResetBtnVisibility() {
+    resetBtn.style.display = hasActiveFilter() ? '' : 'none'
+  }
+
+  resetBtn.addEventListener('click', () => {
+    searchInput.value = ''
+    tagFilter.value = ''
+    sensorFilter.value = ''
+    regionFilter.value = ''
+    sourceFilter.value = ''
+    onlyMineCheckbox.checked = false
+    searchTerm = ''
+    currentPage = 0
+    updateResetBtnVisibility()
+    loadPage()
+  })
+
   function onFilterChange() {
     clearTimeout(debounceTimer)
     debounceTimer = setTimeout(() => {
       searchTerm = searchInput.value.trim()
       currentPage = 0
+      updateResetBtnVisibility()
       loadPage()
     }, 300)
   }
@@ -127,6 +162,7 @@ export function initCatalogUI(onSelectCog) {
   })
   onlyMineCheckbox.addEventListener('change', () => {
     currentPage = 0
+    updateResetBtnVisibility()
     loadPage()
   })
 

--- a/tests/unit/catalogUI.test.js
+++ b/tests/unit/catalogUI.test.js
@@ -774,6 +774,71 @@ describe('catalogUI interactions', () => {
     expect(checkbox.checked).toBe(false)
   })
 
+  it('reset button is hidden when no filters active', async () => {
+    await initAndOpen([{ id: '1', title: 'T', tags: [], created_at: '2026-01-01' }])
+
+    const resetBtn = document.getElementById('catalog-filter-reset')
+    expect(resetBtn).not.toBeNull()
+    expect(resetBtn.style.display).toBe('none')
+  })
+
+  it('reset button appears when a filter is active', async () => {
+    await initAndOpen([{ id: '1', title: 'T', tags: [], created_at: '2026-01-01' }])
+    mockGetCogImages.mockResolvedValue({ data: [], error: null })
+
+    const tagFilter = document.getElementById('catalog-filter-tag')
+    tagFilter.value = 'flood'
+    tagFilter.dispatchEvent(new Event('input'))
+    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(10)
+
+    const resetBtn = document.getElementById('catalog-filter-reset')
+    expect(resetBtn.style.display).toBe('')
+  })
+
+  it('reset button clears all filters and reloads', async () => {
+    await initAndOpen([{ id: '1', title: 'T', tags: [], created_at: '2026-01-01' }])
+    mockGetCogImages.mockResolvedValue({ data: [], error: null })
+
+    // Set multiple filters
+    const searchInput = document.getElementById('catalog-search')
+    const tagFilter = document.getElementById('catalog-filter-tag')
+    const sensorFilter = document.getElementById('catalog-filter-sensor')
+    const regionFilter = document.getElementById('catalog-filter-region')
+    const sourceFilter = document.getElementById('catalog-filter-source')
+    const onlyMine = document.getElementById('catalog-filter-only-mine')
+
+    searchInput.value = 'test'
+    tagFilter.value = 'flood'
+    sensorFilter.value = 'SAR'
+    regionFilter.value = 'Seoul'
+    sourceFilter.value = 'stac'
+    onlyMine.checked = true
+
+    mockGetCogImages.mockClear()
+    mockGetCogImages.mockResolvedValue({ data: [], error: null })
+
+    const resetBtn = document.getElementById('catalog-filter-reset')
+    resetBtn.click()
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(searchInput.value).toBe('')
+    expect(tagFilter.value).toBe('')
+    expect(sensorFilter.value).toBe('')
+    expect(regionFilter.value).toBe('')
+    expect(sourceFilter.value).toBe('')
+    expect(onlyMine.checked).toBe(false)
+    expect(resetBtn.style.display).toBe('none')
+    expect(mockGetCogImages).toHaveBeenCalledWith(expect.objectContaining({
+      search: '',
+      tag: '',
+      sensor: '',
+      region: '',
+      sourceType: '',
+      userId: '',
+    }))
+  })
+
   it('like button handles NaN count gracefully', async () => {
     mockToggleLike.mockResolvedValue({ liked: true, error: null })
     mockGetLikeStates.mockResolvedValue(new Map([['1', { count: 0, liked: false }]]))


### PR DESCRIPTION
## Summary
- 카탈로그 필터 영역에 "필터 초기화" 버튼 추가
- 검색어/태그/센서/지역/출처/내 영상만 필터를 한 번에 초기화
- 필터가 하나라도 활성화된 경우에만 버튼 표시

closes #228

## Test plan
- [x] 필터 초기화 버튼이 필터 비활성 시 숨김 확인 (신규 테스트)
- [x] 필터 활성 시 버튼 표시 확인 (신규 테스트)
- [x] 초기화 클릭 시 모든 필터 초기화 + 재조회 확인 (신규 테스트)
- [x] 기존 테스트 308개 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)