### PR TITLE
feat: 카탈로그 촬영 연도 필터 추가 (captured_at 기반)

### DIFF
--- a/src/catalog.js
+++ b/src/catalog.js
@@ -107,12 +107,13 @@ export async function saveCogImage(data) {
  * @param {string} [options.sensor] - 센서 필터
  * @param {string} [options.region] - 지역 필터
  * @param {string} [options.sourceType] - 등록 출처 필터 ('stac' 또는 'manual', 빈 문자열이면 전체)
+ * @param {string} [options.year] - 촬영 연도 필터 (captured_at 기반, 빈 문자열이면 전체)
  * @param {string} [options.sortBy] - 정렬 기준 ('created_at', 'like_count' 또는 'view_count')
  * @param {string} [options.userId] - 특정 사용자의 영상만 필터 (user_id 기준)
  * @param {number} [options.limit] - 페이지당 결과 수
  * @param {number} [options.offset] - 페이지네이션 오프셋
  */
-export async function getCogImages({ search = '', tag = '', sensor = '', region = '', sourceType = '', sortBy = 'created_at', userId = '', limit = 20, offset = 0 } = {}) {
+export async function getCogImages({ search = '', tag = '', sensor = '', region = '', sourceType = '', year = '', sortBy = 'created_at', userId = '', limit = 20, offset = 0 } = {}) {
   if (!supabase) return { data: [], error: null }
 
   let query = supabase
@@ -139,6 +140,9 @@ export async function getCogImages({ search = '', tag = '', sensor = '', region 
   }
   if (sourceType) {
     query = query.eq('source_type', sourceType)
+  }
+  if (year) {
+    query = query.gte('captured_at', `${year}-01-01T00:00:00Z`).lt('captured_at', `${Number(year) + 1}-01-01T00:00:00Z`)
   }
   if (userId) {
     query = query.eq('user_id', userId)

--- a/src/catalogUI.js
+++ b/src/catalogUI.js
@@ -34,6 +34,9 @@ export function initCatalogUI(onSelectCog) {
       <option value="manual">수동 등록</option>
       <option value="stac">STAC 자동</option>
     </select>
+    <select id="catalog-filter-year" class="catalog-filter-input" aria-label="촬영 연도 필터">
+      <option value="">전체 연도</option>
+    </select>
   `
   searchInput.parentNode.insertBefore(filterContainer, searchInput.nextSibling)
 
@@ -41,6 +44,16 @@ export function initCatalogUI(onSelectCog) {
   const sensorFilter = filterContainer.querySelector('#catalog-filter-sensor')
   const regionFilter = filterContainer.querySelector('#catalog-filter-region')
   const sourceFilter = filterContainer.querySelector('#catalog-filter-source')
+  const yearFilter = filterContainer.querySelector('#catalog-filter-year')
+
+  // 연도 드롭다운 옵션 동적 생성 (현재 연도부터 5년 전까지)
+  const currentYear = new Date().getFullYear()
+  for (let y = currentYear; y >= currentYear - 5; y--) {
+    const opt = document.createElement('option')
+    opt.value = String(y)
+    opt.textContent = `${y}년`
+    yearFilter.appendChild(opt)
+  }
 
   // 필터 초기화 버튼
   const resetBtn = document.createElement('button')
@@ -120,6 +133,7 @@ export function initCatalogUI(onSelectCog) {
       sensorFilter.value.trim() !== '' ||
       regionFilter.value.trim() !== '' ||
       sourceFilter.value !== '' ||
+      yearFilter.value !== '' ||
       onlyMineCheckbox.checked
   }
 
@@ -133,6 +147,7 @@ export function initCatalogUI(onSelectCog) {
     sensorFilter.value = ''
     regionFilter.value = ''
     sourceFilter.value = ''
+    yearFilter.value = ''
     onlyMineCheckbox.checked = false
     searchTerm = ''
     currentPage = 0
@@ -155,6 +170,7 @@ export function initCatalogUI(onSelectCog) {
   sensorFilter.addEventListener('input', onFilterChange)
   regionFilter.addEventListener('input', onFilterChange)
   sourceFilter.addEventListener('change', onFilterChange)
+  yearFilter.addEventListener('change', onFilterChange)
   sortSelect.addEventListener('change', () => {
     sortBy = sortSelect.value
     currentPage = 0
@@ -196,6 +212,7 @@ export function initCatalogUI(onSelectCog) {
       sensor: sensorFilter.value.trim(),
       region: regionFilter.value.trim(),
       sourceType: sourceFilter.value,
+      year: yearFilter.value,
       sortBy,
       userId: onlyMineCheckbox.checked ? currentUserId : '',
       limit: PAGE_SIZE,

--- a/tests/unit/catalog.test.js
+++ b/tests/unit/catalog.test.js
@@ -13,6 +13,8 @@ const { mockSupabase, setMockQuery, createQueryMock, mockDetectBands } = vi.hois
       or: vi.fn().mockReturnThis(),
       contains: vi.fn().mockReturnThis(),
       ilike: vi.fn().mockReturnThis(),
+      gte: vi.fn().mockReturnThis(),
+      lt: vi.fn().mockReturnThis(),
       order: vi.fn().mockReturnThis(),
       range: vi.fn().mockReturnThis(),
       single: vi.fn().mockResolvedValue(result),
@@ -244,6 +246,22 @@ describe('getCogImages', () => {
     setMockQuery(q)
     await getCogImages({ userId: '' })
     expect(q.eq).not.toHaveBeenCalled()
+  })
+
+  it('applies year filter with gte and lt on captured_at', async () => {
+    const q = createQueryMock([])
+    setMockQuery(q)
+    await getCogImages({ year: '2025' })
+    expect(q.gte).toHaveBeenCalledWith('captured_at', '2025-01-01T00:00:00Z')
+    expect(q.lt).toHaveBeenCalledWith('captured_at', '2026-01-01T00:00:00Z')
+  })
+
+  it('does not apply year filter when empty', async () => {
+    const q = createQueryMock([])
+    setMockQuery(q)
+    await getCogImages({ year: '' })
+    expect(q.gte).not.toHaveBeenCalled()
+    expect(q.lt).not.toHaveBeenCalled()
   })
 
   it('sorts by like_count client-side', async () => {

--- a/tests/unit/catalogUI.test.js
+++ b/tests/unit/catalogUI.test.js
@@ -550,6 +550,30 @@ describe('catalogUI interactions', () => {
     expect(mockGetCogImages).toHaveBeenCalledWith(expect.objectContaining({ sourceType: 'stac' }))
   })
 
+  it('year filter triggers onFilterChange on change event', async () => {
+    await initAndOpen([{ id: '1', title: 'T', tags: [], created_at: '2026-01-01' }])
+    mockGetCogImages.mockClear()
+    mockGetCogImages.mockResolvedValue({ data: [], error: null })
+
+    const yearFilter = document.getElementById('catalog-filter-year')
+    yearFilter.value = '2025'
+    yearFilter.dispatchEvent(new Event('change'))
+    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(mockGetCogImages).toHaveBeenCalledWith(expect.objectContaining({ year: '2025' }))
+  })
+
+  it('year filter dropdown has dynamic year options', async () => {
+    await initAndOpen([{ id: '1', title: 'T', tags: [], created_at: '2026-01-01' }])
+    const yearFilter = document.getElementById('catalog-filter-year')
+    const options = yearFilter.querySelectorAll('option')
+    // '전체 연도' + 6 years
+    expect(options.length).toBe(7)
+    expect(options[0].value).toBe('')
+    expect(options[0].textContent).toBe('전체 연도')
+  })
+
   it('prev button does nothing on first page', async () => {
     await initAndOpen([{ id: '1', title: 'T', tags: [], created_at: '2026-01-01' }])
     mockGetCogImages.mockClear()
@@ -808,11 +832,14 @@ describe('catalogUI interactions', () => {
     const sourceFilter = document.getElementById('catalog-filter-source')
     const onlyMine = document.getElementById('catalog-filter-only-mine')
 
+    const yearFilter = document.getElementById('catalog-filter-year')
+
     searchInput.value = 'test'
     tagFilter.value = 'flood'
     sensorFilter.value = 'SAR'
     regionFilter.value = 'Seoul'
     sourceFilter.value = 'stac'
+    yearFilter.value = '2025'
     onlyMine.checked = true
 
     mockGetCogImages.mockClear()
@@ -827,6 +854,7 @@ describe('catalogUI interactions', () => {
     expect(sensorFilter.value).toBe('')
     expect(regionFilter.value).toBe('')
     expect(sourceFilter.value).toBe('')
+    expect(yearFilter.value).toBe('')
     expect(onlyMine.checked).toBe(false)
     expect(resetBtn.style.display).toBe('none')
     expect(mockGetCogImages).toHaveBeenCalledWith(expect.objectContaining({


### PR DESCRIPTION
## Summary
- `getCogImages`에 `year` 파라미터 추가 — Supabase `.gte`/`.lt`로 `captured_at` 기반 연도 필터링
- `catalogUI.js`에 연도 드롭다운 동적 생성 (현재 연도~5년 전)
- 기존 필터 초기화 버튼에 연도 필터 포함

## Test plan
- [x] 연도 필터 적용 시 gte/lt 파라미터 정상 전달 확인
- [x] 빈 연도일 때 필터 미적용 확인
- [x] UI 드롭다운 옵션 7개(전체 + 6년) 생성 확인
- [x] 초기화 버튼으로 연도 필터 리셋 확인
- [x] 전체 312개 테스트 통과

closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)