### PR TITLE
feat: 카탈로그 '좋아요한 영상만 보기' 필터 추가

### DIFF
--- a/src/catalog.js
+++ b/src/catalog.js
@@ -110,10 +110,11 @@ export async function saveCogImage(data) {
  * @param {string} [options.year] - 촬영 연도 필터 (captured_at 기반, 빈 문자열이면 전체)
  * @param {string} [options.sortBy] - 정렬 기준 ('created_at', 'like_count' 또는 'view_count')
  * @param {string} [options.userId] - 특정 사용자의 영상만 필터 (user_id 기준)
+ * @param {string[]} [options.likedIds] - 좋아요한 영상 ID 목록 (빈 배열이 아닐 때 id IN 필터 적용)
  * @param {number} [options.limit] - 페이지당 결과 수
  * @param {number} [options.offset] - 페이지네이션 오프셋
  */
-export async function getCogImages({ search = '', tag = '', sensor = '', region = '', sourceType = '', year = '', sortBy = 'created_at', userId = '', limit = 20, offset = 0 } = {}) {
+export async function getCogImages({ search = '', tag = '', sensor = '', region = '', sourceType = '', year = '', sortBy = 'created_at', userId = '', likedIds = null, limit = 20, offset = 0 } = {}) {
   if (!supabase) return { data: [], error: null }
 
   let query = supabase
@@ -146,6 +147,12 @@ export async function getCogImages({ search = '', tag = '', sensor = '', region 
   }
   if (userId) {
     query = query.eq('user_id', userId)
+  }
+  if (likedIds) {
+    if (likedIds.length === 0) {
+      return { data: [], error: null }
+    }
+    query = query.in('id', likedIds)
   }
 
   const result = await query

--- a/src/catalogUI.js
+++ b/src/catalogUI.js
@@ -1,6 +1,6 @@
 import { supabase } from './supabase.js'
 import { getCogImages, deleteCogImage, updateCogImage, incrementViewCount } from './catalog.js'
-import { toggleLike, getLikeStates } from './likes.js'
+import { toggleLike, getLikeStates, getLikedImageIds } from './likes.js'
 import { getSession } from './auth.js'
 
 const PAGE_SIZE = 20
@@ -73,6 +73,16 @@ export function initCatalogUI(onSelectCog) {
   filterContainer.parentNode.insertBefore(onlyMineContainer, filterContainer.nextSibling)
   const onlyMineCheckbox = onlyMineContainer.querySelector('#catalog-filter-only-mine')
 
+  // 좋아요한 영상만 보기 필터 (로그인 시에만 표시)
+  const likedOnlyContainer = document.createElement('div')
+  likedOnlyContainer.className = 'catalog-liked-only'
+  likedOnlyContainer.style.display = 'none'
+  likedOnlyContainer.innerHTML = `
+    <label><input type="checkbox" id="catalog-filter-liked-only"> 좋아요한 영상만</label>
+  `
+  onlyMineContainer.parentNode.insertBefore(likedOnlyContainer, onlyMineContainer.nextSibling)
+  const likedOnlyCheckbox = likedOnlyContainer.querySelector('#catalog-filter-liked-only')
+
   // 정렬 드롭다운
   const sortContainer = document.createElement('div')
   sortContainer.className = 'catalog-sort'
@@ -83,7 +93,7 @@ export function initCatalogUI(onSelectCog) {
       <option value="view_count">조회수순</option>
     </select>
   `
-  onlyMineContainer.parentNode.insertBefore(sortContainer, onlyMineContainer.nextSibling)
+  likedOnlyContainer.parentNode.insertBefore(sortContainer, likedOnlyContainer.nextSibling)
   const sortSelect = sortContainer.querySelector('#catalog-sort-select')
 
   let currentPage = 0
@@ -97,8 +107,10 @@ export function initCatalogUI(onSelectCog) {
     isUserLoggedIn = !!session?.user
     currentUserId = session?.user?.id || null
     onlyMineContainer.style.display = isUserLoggedIn ? '' : 'none'
+    likedOnlyContainer.style.display = isUserLoggedIn ? '' : 'none'
     if (!isUserLoggedIn) {
       onlyMineCheckbox.checked = false
+      likedOnlyCheckbox.checked = false
     }
   }
 
@@ -134,7 +146,8 @@ export function initCatalogUI(onSelectCog) {
       regionFilter.value.trim() !== '' ||
       sourceFilter.value !== '' ||
       yearFilter.value !== '' ||
-      onlyMineCheckbox.checked
+      onlyMineCheckbox.checked ||
+      likedOnlyCheckbox.checked
   }
 
   function updateResetBtnVisibility() {
@@ -149,6 +162,7 @@ export function initCatalogUI(onSelectCog) {
     sourceFilter.value = ''
     yearFilter.value = ''
     onlyMineCheckbox.checked = false
+    likedOnlyCheckbox.checked = false
     searchTerm = ''
     currentPage = 0
     updateResetBtnVisibility()
@@ -181,6 +195,11 @@ export function initCatalogUI(onSelectCog) {
     updateResetBtnVisibility()
     loadPage()
   })
+  likedOnlyCheckbox.addEventListener('change', () => {
+    currentPage = 0
+    updateResetBtnVisibility()
+    loadPage()
+  })
 
   prevBtn.addEventListener('click', () => {
     if (currentPage > 0) {
@@ -206,6 +225,7 @@ export function initCatalogUI(onSelectCog) {
     listEl.innerHTML = '<div style="text-align:center;padding:2rem;color:#999;">로딩 중...</div>'
 
     const offset = currentPage * PAGE_SIZE
+    const likedIds = likedOnlyCheckbox.checked ? await getLikedImageIds() : null
     const { data, error } = await getCogImages({
       search: searchTerm,
       tag: tagFilter.value.trim(),
@@ -215,6 +235,7 @@ export function initCatalogUI(onSelectCog) {
       year: yearFilter.value,
       sortBy,
       userId: onlyMineCheckbox.checked ? currentUserId : '',
+      likedIds,
       limit: PAGE_SIZE,
       offset
     })

--- a/src/likes.js
+++ b/src/likes.js
@@ -117,3 +117,21 @@ export async function getLikeStates(cogImageIds) {
 
   return result
 }
+
+/**
+ * 현재 로그인 사용자가 좋아요한 영상 ID 목록 조회
+ * @returns {Promise<string[]>}
+ */
+export async function getLikedImageIds() {
+  if (!supabase) return []
+
+  const { data: { session } } = await supabase.auth.getSession()
+  if (!session?.user) return []
+
+  const { data } = await supabase
+    .from('likes')
+    .select('cog_image_id')
+    .eq('user_id', session.user.id)
+
+  return (data || []).map(row => row.cog_image_id)
+}

--- a/tests/unit/catalog.test.js
+++ b/tests/unit/catalog.test.js
@@ -248,6 +248,29 @@ describe('getCogImages', () => {
     expect(q.eq).not.toHaveBeenCalled()
   })
 
+  it('applies likedIds filter with in operator', async () => {
+    const q = createQueryMock([{ id: 'a' }])
+    q.in = vi.fn().mockReturnThis()
+    setMockQuery(q)
+    await getCogImages({ likedIds: ['a', 'b'] })
+    expect(q.in).toHaveBeenCalledWith('id', ['a', 'b'])
+  })
+
+  it('returns empty data when likedIds is empty array', async () => {
+    const q = createQueryMock([{ id: 'a' }])
+    setMockQuery(q)
+    const result = await getCogImages({ likedIds: [] })
+    expect(result).toEqual({ data: [], error: null })
+  })
+
+  it('does not apply likedIds filter when null', async () => {
+    const q = createQueryMock([{ id: 'a' }])
+    q.in = vi.fn().mockReturnThis()
+    setMockQuery(q)
+    await getCogImages({ likedIds: null })
+    expect(q.in).not.toHaveBeenCalled()
+  })
+
   it('applies year filter with gte and lt on captured_at', async () => {
     const q = createQueryMock([])
     setMockQuery(q)

--- a/tests/unit/likes.test.js
+++ b/tests/unit/likes.test.js
@@ -30,7 +30,7 @@ const { mockSupabase, setMockQuery, createQueryMock, mockSession } = vi.hoisted(
 
 vi.mock('../../src/supabase.js', () => ({ supabase: mockSupabase }))
 
-import { toggleLike, getLikeCount, isLiked, getLikeStates } from '../../src/likes.js'
+import { toggleLike, getLikeCount, isLiked, getLikeStates, getLikedImageIds } from '../../src/likes.js'
 
 const testUser = { id: 'user-1' }
 const testSession = { user: testUser }
@@ -242,5 +242,39 @@ describe('getLikeStates', () => {
 
     const result = await getLikeStates(['img-1'])
     expect(result.get('img-1')).toEqual({ count: 1, liked: false })
+  })
+})
+
+describe('getLikedImageIds', () => {
+  it('returns empty array when not logged in', async () => {
+    mockSession(null)
+    const result = await getLikedImageIds()
+    expect(result).toEqual([])
+  })
+
+  it('returns liked image ids for logged-in user', async () => {
+    mockSession(testSession)
+    const q = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      then: (resolve) => resolve({ data: [{ cog_image_id: 'img-1' }, { cog_image_id: 'img-2' }] }),
+    }
+    setMockQuery(q)
+
+    const result = await getLikedImageIds()
+    expect(result).toEqual(['img-1', 'img-2'])
+  })
+
+  it('returns empty array when data is null', async () => {
+    mockSession(testSession)
+    const q = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      then: (resolve) => resolve({ data: null }),
+    }
+    setMockQuery(q)
+
+    const result = await getLikedImageIds()
+    expect(result).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary
- 카탈로그 패널에 '좋아요한 영상만' 체크박스 필터 추가 (로그인 사용자 전용)
- `likes.js`에 `getLikedImageIds()` 함수 추가하여 현재 사용자의 좋아요 영상 ID 조회
- `catalog.js`의 `getCogImages()`에 `likedIds` 파라미터 추가 (`id IN (...)` 필터)
- 필터 초기화 버튼으로 체크박스 해제 연동

## Test plan
- [x] 단위 테스트 318개 전체 통과
- [ ] 로그인 상태에서 체크박스 표시 확인
- [ ] 비로그인 상태에서 체크박스 숨김 확인
- [ ] 체크 시 좋아요한 영상만 표시 확인
- [ ] 필터 초기화 버튼으로 체크 해제 확인

closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)