### PR TITLE
feat: 카탈로그 촬영일자순 정렬 옵션 추가

### DIFF
--- a/src/catalog.js
+++ b/src/catalog.js
@@ -108,7 +108,7 @@ export async function saveCogImage(data) {
  * @param {string} [options.region] - 지역 필터
  * @param {string} [options.sourceType] - 등록 출처 필터 ('stac' 또는 'manual', 빈 문자열이면 전체)
  * @param {string} [options.year] - 촬영 연도 필터 (captured_at 기반, 빈 문자열이면 전체)
- * @param {string} [options.sortBy] - 정렬 기준 ('created_at', 'like_count' 또는 'view_count')
+ * @param {string} [options.sortBy] - 정렬 기준 ('created_at', 'like_count', 'view_count' 또는 'captured_at')
  * @param {string} [options.userId] - 특정 사용자의 영상만 필터 (user_id 기준)
  * @param {string[]} [options.likedIds] - 좋아요한 영상 ID 목록 (빈 배열이 아닐 때 id IN 필터 적용)
  * @param {number} [options.limit] - 페이지당 결과 수
@@ -169,6 +169,16 @@ export async function getCogImages({ search = '', tag = '', sensor = '', region 
   // 조회수순 정렬: view_count 기준 내림차순 (클라이언트 사이드)
   if (sortBy === 'view_count' && result.data) {
     result.data.sort((a, b) => (b.view_count || 0) - (a.view_count || 0))
+  }
+
+  // 촬영일자순 정렬: captured_at 기준 내림차순, null은 맨 뒤 (클라이언트 사이드)
+  if (sortBy === 'captured_at' && result.data) {
+    result.data.sort((a, b) => {
+      if (!a.captured_at && !b.captured_at) return 0
+      if (!a.captured_at) return 1
+      if (!b.captured_at) return -1
+      return new Date(b.captured_at) - new Date(a.captured_at)
+    })
   }
 
   return result

--- a/src/catalogUI.js
+++ b/src/catalogUI.js
@@ -91,6 +91,7 @@ export function initCatalogUI(onSelectCog) {
       <option value="created_at">최신순</option>
       <option value="like_count">인기순</option>
       <option value="view_count">조회수순</option>
+      <option value="captured_at">촬영일자순</option>
     </select>
   `
   likedOnlyContainer.parentNode.insertBefore(sortContainer, likedOnlyContainer.nextSibling)

--- a/tests/unit/catalog.test.js
+++ b/tests/unit/catalog.test.js
@@ -310,6 +310,28 @@ describe('getCogImages', () => {
     expect(result.data[2].id).toBe('3')
   })
 
+  it('sorts by captured_at descending with nulls last', async () => {
+    const q = createQueryMock([
+      { id: '1', captured_at: '2023-01-01T00:00:00Z' },
+      { id: '2', captured_at: null },
+      { id: '3', captured_at: '2024-06-15T00:00:00Z' },
+      { id: '4', captured_at: null },
+    ])
+    setMockQuery(q)
+    const result = await getCogImages({ sortBy: 'captured_at' })
+    expect(result.data.map(d => d.id)).toEqual(['3', '1', '2', '4'])
+  })
+
+  it('sorts by captured_at handles all nulls', async () => {
+    const q = createQueryMock([
+      { id: '1', captured_at: null },
+      { id: '2', captured_at: null },
+    ])
+    setMockQuery(q)
+    const result = await getCogImages({ sortBy: 'captured_at' })
+    expect(result.data.map(d => d.id)).toEqual(['1', '2'])
+  })
+
   it('sorts by view_count treats missing view_count as 0', async () => {
     const q = createQueryMock([
       { id: '1' },


### PR DESCRIPTION
## Summary
- `catalog.js` `getCogImages`에 `sortBy='captured_at'` 클라이언트 사이드 정렬 추가 (내림차순, null 맨 뒤)
- `catalogUI.js` 정렬 드롭다운에 '촬영일자순' 옵션 추가
- 단위 테스트 2건 추가

closes #244

## Test plan
- [x] `getCogImages({ sortBy: 'captured_at' })` 촬영일자 내림차순 정렬 확인
- [x] `captured_at`이 null인 영상 맨 뒤 배치 확인
- [x] 전체 테스트 324개 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)