### PR TITLE
feat: 카탈로그 카드에 촬영일자(captured_at) 표시

### DIFF
--- a/src/catalogUI.js
+++ b/src/catalogUI.js
@@ -281,11 +281,16 @@ export function initCatalogUI(onSelectCog) {
       if (item.region) metaParts.push(item.region)
       metaParts.push(formatDate(item.created_at))
 
+      const capturedAtHtml = item.captured_at
+        ? `<div class="catalog-card-captured">📷 ${formatDate(item.captured_at)}</div>`
+        : ''
+
       card.innerHTML = `
         ${thumbHtml}
         <div class="catalog-card-title">${sourceBadge} ${escapeHtml(item.title || '제목 없음')}</div>
         <div class="catalog-card-desc">${escapeHtml(item.description || '')}</div>
         ${tagsHtml}
+        ${capturedAtHtml}
         <div class="catalog-card-meta">${metaParts.filter(Boolean).join(' | ')}</div>
       `
 

--- a/tests/unit/catalogUI.test.js
+++ b/tests/unit/catalogUI.test.js
@@ -222,6 +222,23 @@ describe('catalogUI delete button', () => {
 
     expect(document.querySelector('.catalog-delete-btn')).toBeNull()
   })
+
+  it('displays captured_at on card when present', async () => {
+    await openPanelWithItems([
+      { id: '1', user_id: TEST_USER_ID, title: 'With Date', tags: [], created_at: '2026-01-01', captured_at: '2025-06-15T00:00:00Z' },
+    ])
+    const captured = document.querySelector('.catalog-card-captured')
+    expect(captured).not.toBeNull()
+    expect(captured.textContent).toContain('2025-06-15')
+  })
+
+  it('does not display captured_at on card when absent', async () => {
+    await openPanelWithItems([
+      { id: '1', user_id: TEST_USER_ID, title: 'No Date', tags: [], created_at: '2026-01-01' },
+    ])
+    const captured = document.querySelector('.catalog-card-captured')
+    expect(captured).toBeNull()
+  })
 })
 
 describe('catalogUI interactions', () => {


### PR DESCRIPTION
## Summary
- 카탈로그 카드에 `captured_at`이 있으면 📷 YYYY-MM-DD 형식으로 촬영일자 표시
- `captured_at`이 없는 카드에는 아무것도 추가 표시하지 않음
- 관련 단위 테스트 2개 추가

closes #248

## Test plan
- [x] 촬영일자가 있는 카드에 촬영일자 표시 확인
- [x] 촬영일자가 없는 카드에 아무것도 추가 표시되지 않음 확인
- [x] 기존 테스트 62개 전부 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)