### PR TITLE
feat: 카탈로그 카드에 해상도(resolution) 표시

### DIFF
--- a/src/catalogUI.js
+++ b/src/catalogUI.js
@@ -285,12 +285,17 @@ export function initCatalogUI(onSelectCog) {
         ? `<div class="catalog-card-captured">📷 ${formatDate(item.captured_at)}</div>`
         : ''
 
+      const resolutionHtml = item.resolution != null
+        ? `<div class="catalog-card-resolution">📐 ${item.resolution}m</div>`
+        : ''
+
       card.innerHTML = `
         ${thumbHtml}
         <div class="catalog-card-title">${sourceBadge} ${escapeHtml(item.title || '제목 없음')}</div>
         <div class="catalog-card-desc">${escapeHtml(item.description || '')}</div>
         ${tagsHtml}
         ${capturedAtHtml}
+        ${resolutionHtml}
         <div class="catalog-card-meta">${metaParts.filter(Boolean).join(' | ')}</div>
       `
 

--- a/tests/unit/catalogUI.test.js
+++ b/tests/unit/catalogUI.test.js
@@ -239,6 +239,23 @@ describe('catalogUI delete button', () => {
     const captured = document.querySelector('.catalog-card-captured')
     expect(captured).toBeNull()
   })
+
+  it('displays resolution on card when present', async () => {
+    await openPanelWithItems([
+      { id: '1', user_id: TEST_USER_ID, title: 'With Res', tags: [], created_at: '2026-01-01', resolution: 0.5 },
+    ])
+    const el = document.querySelector('.catalog-card-resolution')
+    expect(el).not.toBeNull()
+    expect(el.textContent).toContain('0.5m')
+  })
+
+  it('does not display resolution on card when absent', async () => {
+    await openPanelWithItems([
+      { id: '1', user_id: TEST_USER_ID, title: 'No Res', tags: [], created_at: '2026-01-01' },
+    ])
+    const el = document.querySelector('.catalog-card-resolution')
+    expect(el).toBeNull()
+  })
 })
 
 describe('catalogUI interactions', () => {


### PR DESCRIPTION
## Summary
- 카탈로그 카드에 `resolution` 값이 있으면 📐 `{value}m` 형식으로 해상도 표시
- `captured_at` 표시와 동일한 패턴 적용
- resolution이 null/undefined인 경우 표시하지 않음

closes #253

## Test plan
- [x] resolution 값이 있는 카드에 📐 표시 확인 (테스트 추가)
- [x] resolution 값이 없는 카드에 표시 없음 확인 (테스트 추가)
- [x] 전체 테스트 330개 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)