### PR TITLE
feat: 카탈로그 이름순(가나다/알파벳) 정렬 옵션 추가

### DIFF
--- a/src/catalog.js
+++ b/src/catalog.js
@@ -108,7 +108,7 @@ export async function saveCogImage(data) {
  * @param {string} [options.region] - 지역 필터
  * @param {string} [options.sourceType] - 등록 출처 필터 ('stac' 또는 'manual', 빈 문자열이면 전체)
  * @param {string} [options.year] - 촬영 연도 필터 (captured_at 기반, 빈 문자열이면 전체)
- * @param {string} [options.sortBy] - 정렬 기준 ('created_at', 'like_count', 'view_count' 또는 'captured_at')
+ * @param {string} [options.sortBy] - 정렬 기준 ('created_at', 'like_count', 'view_count', 'captured_at' 또는 'title')
  * @param {string} [options.userId] - 특정 사용자의 영상만 필터 (user_id 기준)
  * @param {string[]} [options.likedIds] - 좋아요한 영상 ID 목록 (빈 배열이 아닐 때 id IN 필터 적용)
  * @param {number} [options.limit] - 페이지당 결과 수
@@ -179,6 +179,11 @@ export async function getCogImages({ search = '', tag = '', sensor = '', region 
       if (!b.captured_at) return -1
       return new Date(b.captured_at) - new Date(a.captured_at)
     })
+  }
+
+  // 이름순 정렬: title 기준 오름차순 (클라이언트 사이드)
+  if (sortBy === 'title' && result.data) {
+    result.data.sort((a, b) => (a.title || '').localeCompare(b.title || ''))
   }
 
   return result

--- a/src/catalogUI.js
+++ b/src/catalogUI.js
@@ -92,6 +92,7 @@ export function initCatalogUI(onSelectCog) {
       <option value="like_count">인기순</option>
       <option value="view_count">조회수순</option>
       <option value="captured_at">촬영일자순</option>
+      <option value="title">이름순</option>
     </select>
   `
   likedOnlyContainer.parentNode.insertBefore(sortContainer, likedOnlyContainer.nextSibling)

--- a/tests/unit/catalog.test.js
+++ b/tests/unit/catalog.test.js
@@ -332,6 +332,28 @@ describe('getCogImages', () => {
     expect(result.data.map(d => d.id)).toEqual(['1', '2'])
   })
 
+  it('sorts by title ascending', async () => {
+    const q = createQueryMock([
+      { id: '1', title: 'Cherry' },
+      { id: '2', title: 'Apple' },
+      { id: '3', title: 'Banana' },
+    ])
+    setMockQuery(q)
+    const result = await getCogImages({ sortBy: 'title' })
+    expect(result.data.map(d => d.id)).toEqual(['2', '3', '1'])
+  })
+
+  it('sorts by title treats missing title as empty string', async () => {
+    const q = createQueryMock([
+      { id: '1', title: 'Banana' },
+      { id: '2' },
+      { id: '3', title: 'Apple' },
+    ])
+    setMockQuery(q)
+    const result = await getCogImages({ sortBy: 'title' })
+    expect(result.data.map(d => d.id)).toEqual(['2', '3', '1'])
+  })
+
   it('sorts by view_count treats missing view_count as 0', async () => {
     const q = createQueryMock([
       { id: '1' },

--- a/tests/unit/catalogUI.test.js
+++ b/tests/unit/catalogUI.test.js
@@ -363,6 +363,26 @@ describe('catalogUI interactions', () => {
     expect(mockGetCogImages).toHaveBeenCalledWith(expect.objectContaining({ sortBy: 'view_count' }))
   })
 
+  it('sort select includes title option', async () => {
+    await initAndOpen([{ id: '1', title: 'T', tags: [], created_at: '2026-01-01' }])
+    const sortSelect = document.getElementById('catalog-sort-select')
+    const options = Array.from(sortSelect.options).map(o => o.value)
+    expect(options).toContain('title')
+  })
+
+  it('sort by title triggers loadPage with sortBy title', async () => {
+    await initAndOpen([{ id: '1', title: 'T', tags: [], created_at: '2026-01-01' }])
+    mockGetCogImages.mockClear()
+    mockGetCogImages.mockResolvedValue({ data: [], error: null })
+
+    const sortSelect = document.getElementById('catalog-sort-select')
+    sortSelect.value = 'title'
+    sortSelect.dispatchEvent(new Event('change'))
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(mockGetCogImages).toHaveBeenCalledWith(expect.objectContaining({ sortBy: 'title' }))
+  })
+
   it('prev button navigates back', async () => {
     // First load returns full page to enable next
     const items = Array.from({ length: 20 }, (_, i) => ({ id: String(i), title: `T${i}`, tags: [], created_at: '2026-01-01' }))


### PR DESCRIPTION
## Summary
- `catalog.js`: `sortBy='title'` 옵션 추가 — `localeCompare`로 오름차순 정렬
- `catalogUI.js`: 정렬 드롭다운에 '이름순' 옵션 추가
- 테스트 4개 추가 (catalog.test.js 2개, catalogUI.test.js 2개)

closes #257

## Test plan
- [x] 이름순 정렬 시 title 알파벳/가나다순 정렬 확인
- [x] title 없는 항목은 빈 문자열로 처리
- [x] UI 드롭다운에 title 옵션 존재 확인
- [x] 전체 테스트 334개 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)