### PR TITLE
feat: 카탈로그 페이지당 영상 수 변경 옵션 추가

### DIFF
--- a/src/catalogUI.js
+++ b/src/catalogUI.js
@@ -3,7 +3,7 @@ import { getCogImages, deleteCogImage, updateCogImage, incrementViewCount, DEFAU
 import { toggleLike, getLikeStates, getLikedImageIds } from './likes.js'
 import { getSession } from './auth.js'
 
-const PAGE_SIZE = 20
+const DEFAULT_PAGE_SIZE = 20
 
 /**
  * 카탈로그 사이드바 UI 초기화
@@ -100,12 +100,28 @@ export function initCatalogUI(onSelectCog) {
   const sortSelect = sortContainer.querySelector('#catalog-sort-select')
   const sortOrderBtn = sortContainer.querySelector('#catalog-sort-order-btn')
 
+  // 페이지당 영상 수 드롭다운
+  const pageSizeContainer = document.createElement('div')
+  pageSizeContainer.className = 'catalog-page-size'
+  pageSizeContainer.innerHTML = `
+    <label>
+      <select id="catalog-page-size-select" class="catalog-filter-input" aria-label="페이지당 영상 수">
+        <option value="10">10개씩</option>
+        <option value="20" selected>20개씩</option>
+        <option value="50">50개씩</option>
+      </select>
+    </label>
+  `
+  sortContainer.parentNode.insertBefore(pageSizeContainer, sortContainer.nextSibling)
+  const pageSizeSelect = pageSizeContainer.querySelector('#catalog-page-size-select')
+
   // 총 영상 수 표시
   const totalCountEl = document.createElement('div')
   totalCountEl.id = 'catalog-total-count'
   totalCountEl.className = 'catalog-total-count'
-  sortContainer.parentNode.insertBefore(totalCountEl, sortContainer.nextSibling)
+  pageSizeContainer.parentNode.insertBefore(totalCountEl, pageSizeContainer.nextSibling)
 
+  let pageSize = DEFAULT_PAGE_SIZE
   let currentPage = 0
   let searchTerm = ''
   let sortBy = 'created_at'
@@ -214,6 +230,11 @@ export function initCatalogUI(onSelectCog) {
     currentPage = 0
     loadPage()
   })
+  pageSizeSelect.addEventListener('change', () => {
+    pageSize = Number(pageSizeSelect.value)
+    currentPage = 0
+    loadPage()
+  })
   onlyMineCheckbox.addEventListener('change', () => {
     currentPage = 0
     updateResetBtnVisibility()
@@ -248,7 +269,7 @@ export function initCatalogUI(onSelectCog) {
   async function loadPage() {
     listEl.innerHTML = '<div style="text-align:center;padding:2rem;color:#999;">로딩 중...</div>'
 
-    const offset = currentPage * PAGE_SIZE
+    const offset = currentPage * pageSize
     const likedIds = likedOnlyCheckbox.checked ? await getLikedImageIds() : null
     const { data, totalCount, error } = await getCogImages({
       search: searchTerm,
@@ -261,7 +282,7 @@ export function initCatalogUI(onSelectCog) {
       sortOrder,
       userId: onlyMineCheckbox.checked ? currentUserId : '',
       likedIds,
-      limit: PAGE_SIZE,
+      limit: pageSize,
       offset
     })
 
@@ -439,7 +460,7 @@ export function initCatalogUI(onSelectCog) {
     })
 
     prevBtn.disabled = currentPage === 0
-    nextBtn.disabled = data.length < PAGE_SIZE
+    nextBtn.disabled = data.length < pageSize
     pageInfo.textContent = `${currentPage + 1}`
     totalCountEl.textContent = `총 ${totalCount}개 영상`
   }

--- a/tests/unit/catalogUI.test.js
+++ b/tests/unit/catalogUI.test.js
@@ -994,6 +994,48 @@ describe('catalogUI interactions', () => {
     }))
   })
 
+  it('page size dropdown exists with options 10/20/50', async () => {
+    await initAndOpen([{ id: '1', title: 'T', tags: [], created_at: '2026-01-01' }])
+    const select = document.getElementById('catalog-page-size-select')
+    expect(select).not.toBeNull()
+    const values = Array.from(select.options).map(o => o.value)
+    expect(values).toEqual(['10', '20', '50'])
+    expect(select.value).toBe('20')
+  })
+
+  it('changing page size reloads with new limit and resets page', async () => {
+    const items = Array.from({ length: 20 }, (_, i) => ({ id: String(i), title: `T${i}`, tags: [], created_at: '2026-01-01' }))
+    await initAndOpen(items)
+
+    // Go to page 2 first
+    mockGetCogImages.mockResolvedValue({ data: [{ id: '20', title: 'T20', tags: [], created_at: '2026-01-01' }], totalCount: 21, error: null })
+    document.getElementById('catalog-next').click()
+    await vi.advanceTimersByTimeAsync(10)
+
+    mockGetCogImages.mockClear()
+    mockGetCogImages.mockResolvedValue({ data: [], totalCount: 0, error: null })
+
+    const select = document.getElementById('catalog-page-size-select')
+    select.value = '10'
+    select.dispatchEvent(new Event('change'))
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(mockGetCogImages).toHaveBeenCalledWith(expect.objectContaining({ limit: 10, offset: 0 }))
+  })
+
+  it('changing page size to 50 passes limit 50', async () => {
+    await initAndOpen([{ id: '1', title: 'T', tags: [], created_at: '2026-01-01' }])
+    mockGetCogImages.mockClear()
+    mockGetCogImages.mockResolvedValue({ data: [], totalCount: 0, error: null })
+
+    const select = document.getElementById('catalog-page-size-select')
+    select.value = '50'
+    select.dispatchEvent(new Event('change'))
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(mockGetCogImages).toHaveBeenCalledWith(expect.objectContaining({ limit: 50 }))
+  })
+
   it('like button handles NaN count gracefully', async () => {
     mockToggleLike.mockResolvedValue({ liked: true, error: null })
     mockGetLikeStates.mockResolvedValue(new Map([['1', { count: 0, liked: false }]]))


### PR DESCRIPTION
## Summary
- 카탈로그 패널에 페이지당 영상 수 드롭다운(10/20/50) 추가
- 값 변경 시 첫 페이지로 초기화되어 다시 로드
- 기본값 20 유지, 기존 동작 변경 없음

closes #269

## Test plan
- [x] 드롭다운 UI 렌더링 확인 (10/20/50 옵션)
- [x] 페이지 사이즈 변경 시 limit 파라미터 반영 테스트
- [x] 페이지 사이즈 변경 시 페이지 초기화(offset: 0) 테스트
- [x] 기존 351개 테스트 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)