### PR TITLE
fix: watchlist 이벤트 리스너 메모리 누수 해결 및 제거 모달 연동

### DIFF
--- a/src/catalogUI.js
+++ b/src/catalogUI.js
@@ -127,6 +127,7 @@ export function initCatalogUI(onSelectCog) {
   let searchTerm = ''
   let sortBy = 'created_at'
   let sortOrder = DEFAULT_SORT_ORDERS[sortBy]
+  let watchlistAbort = null
 
   function updateSortOrderBtn() {
     sortOrderBtn.textContent = sortOrder === 'asc' ? '↑' : '↓'
@@ -304,6 +305,10 @@ export function initCatalogUI(onSelectCog) {
 
     listEl.innerHTML = ''
 
+    // 이전 watchlist-state-changed 리스너 정리
+    if (watchlistAbort) watchlistAbort.abort()
+    watchlistAbort = new AbortController()
+
     // 좋아요·관심목록 상태 일괄 조회
     const ids = data.map(item => item.id)
     const [likeStates, watchlistedIds] = await Promise.all([
@@ -391,7 +396,7 @@ export function initCatalogUI(onSelectCog) {
           const added = e.detail.watchlisted
           watchlistBtn.classList.toggle('watchlisted', added)
           watchlistBtn.textContent = added ? '✓ 관심목록' : '+ 관심목록'
-        })
+        }, { signal: watchlistAbort.signal })
 
         actionsRow.appendChild(likeBtn)
         actionsRow.appendChild(watchlistBtn)

--- a/src/watchlistUI.js
+++ b/src/watchlistUI.js
@@ -59,6 +59,13 @@ export function initWatchlistUI(onSelectCog) {
     openAddToWatchlistModal(cogImageId)
   })
 
+  // 관심목록에서 제거 이벤트 수신
+  document.addEventListener('watchlist-remove', async (e) => {
+    const cogImageId = e.detail?.cogImageId
+    if (!cogImageId) return
+    await openRemoveFromWatchlistModal(cogImageId)
+  })
+
   async function loadWatchlists() {
     listEl.innerHTML = '<div style="text-align:center;padding:2rem;color:#999;">로딩 중...</div>'
 
@@ -306,7 +313,88 @@ export function initWatchlistUI(onSelectCog) {
           btn.textContent = addError.message.includes('duplicate') ? '이미 추가됨' : addError.message
           btn.disabled = false
         } else {
+          document.dispatchEvent(new CustomEvent('watchlist-state-changed', { detail: { cogImageId, watchlisted: true } }))
           overlay.remove()
+        }
+      })
+      listContainer.appendChild(btn)
+    })
+  }
+
+  async function openRemoveFromWatchlistModal(cogImageId) {
+    if (document.getElementById('watchlist-remove-overlay')) return
+
+    const overlay = document.createElement('div')
+    overlay.id = 'watchlist-remove-overlay'
+    overlay.className = 'login-modal-overlay'
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) overlay.remove()
+    })
+
+    const modal = document.createElement('div')
+    modal.className = 'login-modal'
+    modal.style.width = '300px'
+
+    const closeModalBtn = document.createElement('button')
+    closeModalBtn.className = 'login-modal-close'
+    closeModalBtn.textContent = '✕'
+    closeModalBtn.addEventListener('click', () => overlay.remove())
+    modal.appendChild(closeModalBtn)
+
+    const titleEl = document.createElement('h2')
+    titleEl.className = 'login-modal-title'
+    titleEl.textContent = '관심목록에서 제거'
+    modal.appendChild(titleEl)
+
+    const listContainer = document.createElement('div')
+    listContainer.style.cssText = 'max-height:200px;overflow-y:auto;'
+    listContainer.innerHTML = '<div style="text-align:center;padding:1rem;color:#999;">로딩 중...</div>'
+    modal.appendChild(listContainer)
+
+    const onEscape = (e) => {
+      if (e.key === 'Escape') { overlay.remove(); document.removeEventListener('keydown', onEscape) }
+    }
+    document.addEventListener('keydown', onEscape)
+
+    overlay.appendChild(modal)
+    document.body.appendChild(overlay)
+
+    const { data: watchlists } = await getWatchlists()
+    if (!watchlists || watchlists.length === 0) {
+      listContainer.innerHTML = '<div style="text-align:center;padding:1rem;color:#999;">관심목록이 없습니다.</div>'
+      return
+    }
+
+    // 이 영상이 포함된 관심목록만 필터링
+    const containingWatchlists = []
+    for (const wl of watchlists) {
+      const { data: items } = await getWatchlistItems(wl.id)
+      if (items && items.some(i => i.cog_image_id === cogImageId)) {
+        containingWatchlists.push(wl)
+      }
+    }
+
+    if (containingWatchlists.length === 0) {
+      listContainer.innerHTML = '<div style="text-align:center;padding:1rem;color:#999;">이 영상이 포함된 관심목록이 없습니다.</div>'
+      return
+    }
+
+    listContainer.innerHTML = ''
+    containingWatchlists.forEach(wl => {
+      const btn = document.createElement('button')
+      btn.style.cssText = 'display:block;width:100%;padding:0.6rem 0.75rem;border:1px solid #e5e7eb;border-radius:6px;background:white;text-align:left;cursor:pointer;margin-bottom:0.5rem;font-size:0.85rem;color:#dc2626;'
+      btn.textContent = `${wl.name}에서 제거`
+      btn.addEventListener('click', async () => {
+        btn.disabled = true
+        btn.textContent = '제거 중...'
+        const { error: removeError } = await removeItem(wl.id, cogImageId)
+        if (removeError) {
+          btn.textContent = removeError.message
+          btn.disabled = false
+        } else {
+          document.dispatchEvent(new CustomEvent('watchlist-state-changed', { detail: { cogImageId, watchlisted: false } }))
+          overlay.remove()
+          loadWatchlists()
         }
       })
       listContainer.appendChild(btn)

--- a/tests/unit/catalogUI.test.js
+++ b/tests/unit/catalogUI.test.js
@@ -641,6 +641,34 @@ describe('catalogUI interactions', () => {
     expect(btn.textContent).toBe('✓ 관심목록')
   })
 
+  it('watchlist-state-changed listeners are cleaned up on re-render (AbortController)', async () => {
+    const item = { id: '1', user_id: 'other', title: 'T', tags: [], created_at: '2026-01-01' }
+    await initAndOpen([item])
+
+    const btn1 = document.querySelector('.catalog-watchlist-btn')
+    expect(btn1.classList.contains('watchlisted')).toBe(false)
+
+    // Re-render (loadPage called again via pagination)
+    mockGetCogImages.mockResolvedValue({ data: [item], totalCount: 1, error: null })
+    document.querySelector('#catalog-next').click()
+    await vi.advanceTimersByTimeAsync(10)
+
+    // Go back
+    document.querySelector('#catalog-prev').click()
+    await vi.advanceTimersByTimeAsync(10)
+
+    const btn2 = document.querySelector('.catalog-watchlist-btn')
+
+    // Spy on classList.toggle to count calls
+    const toggleSpy = vi.spyOn(btn2.classList, 'toggle')
+
+    document.dispatchEvent(new CustomEvent('watchlist-state-changed', { detail: { cogImageId: '1', watchlisted: true } }))
+
+    // Should only be called once (old listeners aborted)
+    expect(toggleSpy.calls?.length ?? toggleSpy.mock.calls.length).toBe(1)
+    toggleSpy.mockRestore()
+  })
+
   it('shows like count for non-logged-in users', async () => {
     mockGetSession.mockResolvedValue(null)
     mockGetCogImages.mockResolvedValue({

--- a/tests/unit/watchlistUI.test.js
+++ b/tests/unit/watchlistUI.test.js
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const {
+  mockSupabase, mockGetSession, mockOnAuthStateChange,
+  mockGetWatchlists, mockCreateWatchlist, mockDeleteWatchlist,
+  mockAddItem, mockRemoveItem, mockGetWatchlistItems,
+} = vi.hoisted(() => {
+  const mockOnAuthStateChange = vi.fn()
+  const mockSupabase = {
+    auth: { onAuthStateChange: mockOnAuthStateChange },
+  }
+  return {
+    mockSupabase,
+    mockGetSession: vi.fn(),
+    mockOnAuthStateChange,
+    mockGetWatchlists: vi.fn(),
+    mockCreateWatchlist: vi.fn(),
+    mockDeleteWatchlist: vi.fn(),
+    mockAddItem: vi.fn(),
+    mockRemoveItem: vi.fn(),
+    mockGetWatchlistItems: vi.fn(),
+  }
+})
+
+vi.mock('../../src/supabase.js', () => ({ supabase: mockSupabase }))
+vi.mock('../../src/auth.js', () => ({ getSession: mockGetSession }))
+vi.mock('../../src/watchlist.js', () => ({
+  getWatchlists: mockGetWatchlists,
+  createWatchlist: mockCreateWatchlist,
+  deleteWatchlist: mockDeleteWatchlist,
+  addItem: mockAddItem,
+  removeItem: mockRemoveItem,
+  getWatchlistItems: mockGetWatchlistItems,
+}))
+
+import { initWatchlistUI } from '../../src/watchlistUI.js'
+
+function setupDOM() {
+  document.body.innerHTML = `
+    <button id="watchlist-toggle-btn" aria-expanded="false" style="display:none"></button>
+    <div id="watchlist-panel">
+      <button id="watchlist-panel-close"></button>
+      <div id="watchlist-list"></div>
+      <button id="watchlist-create-btn"></button>
+    </div>
+  `
+}
+
+describe('watchlistUI', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupDOM()
+    mockGetSession.mockResolvedValue({ user: { id: 'u1' } })
+    mockOnAuthStateChange.mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('watchlist-remove event opens remove modal with containing watchlists', async () => {
+    initWatchlistUI(vi.fn())
+    await new Promise(r => setTimeout(r, 10))
+
+    mockGetWatchlists.mockResolvedValue({ data: [
+      { id: 'wl1', name: 'My List' },
+      { id: 'wl2', name: 'Other List' },
+    ] })
+    mockGetWatchlistItems
+      .mockResolvedValueOnce({ data: [{ cog_image_id: 'img1' }] })
+      .mockResolvedValueOnce({ data: [{ cog_image_id: 'img2' }] })
+
+    document.dispatchEvent(new CustomEvent('watchlist-remove', { detail: { cogImageId: 'img1' } }))
+    await new Promise(r => setTimeout(r, 50))
+
+    const overlay = document.getElementById('watchlist-remove-overlay')
+    expect(overlay).not.toBeNull()
+
+    const buttons = overlay.querySelectorAll('button:not(.login-modal-close)')
+    expect(buttons.length).toBe(1)
+    expect(buttons[0].textContent).toBe('My List에서 제거')
+  })
+
+  it('remove modal dispatches watchlist-state-changed after removal', async () => {
+    initWatchlistUI(vi.fn())
+    await new Promise(r => setTimeout(r, 10))
+
+    mockGetWatchlists.mockResolvedValue({ data: [{ id: 'wl1', name: 'List' }] })
+    mockGetWatchlistItems.mockResolvedValue({ data: [{ cog_image_id: 'img1' }] })
+    mockRemoveItem.mockResolvedValue({ error: null })
+
+    const stateEvents = []
+    document.addEventListener('watchlist-state-changed', (e) => stateEvents.push(e.detail))
+
+    document.dispatchEvent(new CustomEvent('watchlist-remove', { detail: { cogImageId: 'img1' } }))
+    await new Promise(r => setTimeout(r, 50))
+
+    const overlay = document.getElementById('watchlist-remove-overlay')
+    const removeBtn = overlay.querySelectorAll('button:not(.login-modal-close)')[0]
+    removeBtn.click()
+    await new Promise(r => setTimeout(r, 50))
+
+    expect(stateEvents).toEqual([{ cogImageId: 'img1', watchlisted: false }])
+    expect(document.getElementById('watchlist-remove-overlay')).toBeNull()
+  })
+
+  it('add modal dispatches watchlist-state-changed after adding', async () => {
+    initWatchlistUI(vi.fn())
+    await new Promise(r => setTimeout(r, 10))
+
+    mockGetWatchlists.mockResolvedValue({ data: [{ id: 'wl1', name: 'List' }] })
+    mockAddItem.mockResolvedValue({ error: null })
+
+    const stateEvents = []
+    document.addEventListener('watchlist-state-changed', (e) => stateEvents.push(e.detail))
+
+    document.dispatchEvent(new CustomEvent('watchlist-add', { detail: { cogImageId: 'img1' } }))
+    await new Promise(r => setTimeout(r, 50))
+
+    const overlay = document.getElementById('watchlist-add-overlay')
+    const addBtn = overlay.querySelectorAll('button:not(.login-modal-close)')[0]
+    addBtn.click()
+    await new Promise(r => setTimeout(r, 50))
+
+    expect(stateEvents).toEqual([{ cogImageId: 'img1', watchlisted: true }])
+  })
+})


### PR DESCRIPTION
## Summary
- **#276**: `catalogUI.js`에서 `loadPage()` 호출마다 `watchlist-state-changed` 리스너가 누적되는 메모리 누수를 `AbortController`로 해결
- **#279**: `watchlistUI.js`에 `openRemoveFromWatchlistModal` 함수를 `initWatchlistUI` 스코프 내에 추가하여 카탈로그 카드 제거 버튼과 연동, `watchlist-state-changed` 이벤트 dispatch 추가

closes #276
closes #279

## Test plan
- [x] 기존 362개 테스트 통과
- [x] AbortController 리스너 정리 테스트 추가 (catalogUI.test.js)
- [x] watchlistUI 제거 모달 테스트 3건 추가 (watchlistUI.test.js)
- [ ] 수동: 카탈로그 카드 ✓ 관심목록 버튼 클릭 → 제거 모달 표시 확인
- [ ] 수동: 제거 완료 후 카드 버튼이 '+ 관심목록'으로 복귀 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)