### PR TITLE
feat: 카탈로그 필터/정렬 상태 URL 쿼리스트링 동기화

### DIFF
--- a/src/catalogUI.js
+++ b/src/catalogUI.js
@@ -133,6 +133,64 @@ export function initCatalogUI(onSelectCog) {
     sortOrderBtn.textContent = sortOrder === 'asc' ? '↑' : '↓'
     sortOrderBtn.title = sortOrder === 'asc' ? '오름차순' : '내림차순'
   }
+
+  // URL 쿼리스트링 → UI 상태 복원
+  function readUrlParams() {
+    const params = new URLSearchParams(window.location.search)
+    if (params.has('search')) searchInput.value = params.get('search')
+    if (params.has('tag')) tagFilter.value = params.get('tag')
+    if (params.has('sensor')) sensorFilter.value = params.get('sensor')
+    if (params.has('region')) regionFilter.value = params.get('region')
+    if (params.has('source')) sourceFilter.value = params.get('source')
+    if (params.has('year')) yearFilter.value = params.get('year')
+    if (params.has('sortBy')) {
+      sortBy = params.get('sortBy')
+      sortSelect.value = sortBy
+    }
+    if (params.has('sortOrder')) {
+      sortOrder = params.get('sortOrder')
+    }
+    if (params.get('likedOnly') === 'true') likedOnlyCheckbox.checked = true
+    if (params.get('myImagesOnly') === 'true') onlyMineCheckbox.checked = true
+    searchTerm = searchInput.value.trim()
+    updateSortOrderBtn()
+    updateResetBtnVisibility()
+  }
+
+  // UI 상태 → URL 쿼리스트링 동기화
+  function syncUrlToState() {
+    const params = new URLSearchParams(window.location.search)
+    const defaults = {
+      search: '', tag: '', sensor: '', region: '', source: '', year: '',
+      sortBy: 'created_at', sortOrder: DEFAULT_SORT_ORDERS['created_at'],
+      likedOnly: 'false', myImagesOnly: 'false'
+    }
+    const current = {
+      search: searchTerm,
+      tag: tagFilter.value.trim(),
+      sensor: sensorFilter.value.trim(),
+      region: regionFilter.value.trim(),
+      source: sourceFilter.value,
+      year: yearFilter.value,
+      sortBy,
+      sortOrder,
+      likedOnly: String(likedOnlyCheckbox.checked),
+      myImagesOnly: String(onlyMineCheckbox.checked)
+    }
+    for (const [key, val] of Object.entries(current)) {
+      if (val !== defaults[key]) {
+        params.set(key, val)
+      } else {
+        params.delete(key)
+      }
+    }
+    const qs = params.toString()
+    const newUrl = window.location.pathname + (qs ? '?' + qs : '')
+    history.replaceState(null, '', newUrl)
+  }
+
+  readUrlParams()
+
   let debounceTimer = null
   let isUserLoggedIn = false
   let currentUserId = null
@@ -269,6 +327,7 @@ export function initCatalogUI(onSelectCog) {
   })
 
   async function loadPage() {
+    syncUrlToState()
     listEl.innerHTML = '<div style="text-align:center;padding:2rem;color:#999;">로딩 중...</div>'
 
     const offset = currentPage * pageSize

--- a/tests/unit/catalogUI.test.js
+++ b/tests/unit/catalogUI.test.js
@@ -276,10 +276,12 @@ describe('catalogUI interactions', () => {
     mockOnAuthStateChange.mockImplementation(() => {})
     mockGetLikeStates.mockResolvedValue(new Map())
     mockGetWatchlistedImageIds.mockResolvedValue(new Set())
+    window.history.replaceState(null, '', window.location.pathname)
   })
 
   afterEach(() => {
     vi.useRealTimers()
+    window.history.replaceState(null, '', window.location.pathname)
   })
 
   async function initAndOpen(items, onSelect) {
@@ -1155,5 +1157,147 @@ describe('catalogUI interactions', () => {
 
     // NaN || 0 → 0, liked → 0 + 1 = 1
     expect(likeBtn.querySelector('.like-count').textContent).toBe('1')
+  })
+})
+
+describe('catalogUI URL query string sync', () => {
+  const TEST_USER_ID = 'user-123'
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    setupDOM()
+    mockGetSession.mockResolvedValue({ user: { id: TEST_USER_ID } })
+    mockOnAuthStateChange.mockImplementation(() => {})
+    mockGetLikeStates.mockResolvedValue(new Map())
+    mockGetWatchlistedImageIds.mockResolvedValue(new Set())
+    // Reset URL
+    window.history.replaceState(null, '', window.location.pathname)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    window.history.replaceState(null, '', window.location.pathname)
+  })
+
+  async function initAndOpen(items, onSelect = vi.fn()) {
+    mockGetCogImages.mockResolvedValue({ data: items, totalCount: items.length, error: null })
+    initCatalogUI(onSelect)
+    await vi.advanceTimersByTimeAsync(10)
+    document.getElementById('catalog-toggle-btn').click()
+    await vi.advanceTimersByTimeAsync(10)
+    return onSelect
+  }
+
+  it('updates URL when tag filter is applied', async () => {
+    await initAndOpen([{ id: '1', title: 'T', tags: [], created_at: '2026-01-01' }])
+    mockGetCogImages.mockResolvedValue({ data: [], totalCount: 0, error: null })
+
+    const tagFilter = document.getElementById('catalog-filter-tag')
+    tagFilter.value = 'flood'
+    tagFilter.dispatchEvent(new Event('input'))
+    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(10)
+
+    const params = new URLSearchParams(window.location.search)
+    expect(params.get('tag')).toBe('flood')
+  })
+
+  it('removes default values from URL', async () => {
+    await initAndOpen([{ id: '1', title: 'T', tags: [], created_at: '2026-01-01' }])
+
+    const params = new URLSearchParams(window.location.search)
+    expect(params.has('sortBy')).toBe(false)
+    expect(params.has('sortOrder')).toBe(false)
+    expect(params.has('search')).toBe(false)
+  })
+
+  it('updates URL when sort is changed', async () => {
+    await initAndOpen([{ id: '1', title: 'T', tags: [], created_at: '2026-01-01' }])
+    mockGetCogImages.mockResolvedValue({ data: [], totalCount: 0, error: null })
+
+    const sortSelect = document.getElementById('catalog-sort-select')
+    sortSelect.value = 'title'
+    sortSelect.dispatchEvent(new Event('change'))
+    await vi.advanceTimersByTimeAsync(10)
+
+    const params = new URLSearchParams(window.location.search)
+    expect(params.get('sortBy')).toBe('title')
+    expect(params.get('sortOrder')).toBe('asc')
+  })
+
+  it('restores filters from URL on init', async () => {
+    window.history.replaceState(null, '', '?tag=flood&sensor=SAR&sortBy=title&sortOrder=asc')
+    mockGetCogImages.mockResolvedValue({ data: [], totalCount: 0, error: null })
+
+    initCatalogUI(vi.fn())
+    await vi.advanceTimersByTimeAsync(10)
+
+    document.getElementById('catalog-toggle-btn').click()
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(document.getElementById('catalog-filter-tag').value).toBe('flood')
+    expect(document.getElementById('catalog-filter-sensor').value).toBe('SAR')
+    expect(document.getElementById('catalog-sort-select').value).toBe('title')
+    expect(mockGetCogImages).toHaveBeenCalledWith(expect.objectContaining({
+      tag: 'flood',
+      sensor: 'SAR',
+      sortBy: 'title',
+      sortOrder: 'asc',
+    }))
+  })
+
+  it('restores boolean filters from URL', async () => {
+    window.history.replaceState(null, '', '?likedOnly=true&myImagesOnly=true')
+    mockGetCogImages.mockResolvedValue({ data: [], totalCount: 0, error: null })
+
+    initCatalogUI(vi.fn())
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(document.getElementById('catalog-filter-liked-only').checked).toBe(true)
+    expect(document.getElementById('catalog-filter-only-mine').checked).toBe(true)
+  })
+
+  it('clears URL params on filter reset', async () => {
+    window.history.replaceState(null, '', '?tag=flood&sensor=SAR')
+    await initAndOpen([{ id: '1', title: 'T', tags: [], created_at: '2026-01-01' }])
+    mockGetCogImages.mockResolvedValue({ data: [], totalCount: 0, error: null })
+
+    document.getElementById('catalog-filter-reset').click()
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(window.location.search).toBe('')
+  })
+
+  it('updates URL with multiple filters', async () => {
+    await initAndOpen([{ id: '1', title: 'T', tags: [], created_at: '2026-01-01' }])
+    mockGetCogImages.mockResolvedValue({ data: [], totalCount: 0, error: null })
+
+    document.getElementById('catalog-filter-tag').value = 'flood'
+    document.getElementById('catalog-filter-sensor').value = 'SAR'
+    document.getElementById('catalog-filter-source').value = 'stac'
+    document.getElementById('catalog-filter-source').dispatchEvent(new Event('change'))
+    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(10)
+
+    const params = new URLSearchParams(window.location.search)
+    expect(params.get('tag')).toBe('flood')
+    expect(params.get('sensor')).toBe('SAR')
+    expect(params.get('source')).toBe('stac')
+  })
+
+  it('restores search term from URL', async () => {
+    window.history.replaceState(null, '', '?search=satellite')
+    mockGetCogImages.mockResolvedValue({ data: [], totalCount: 0, error: null })
+
+    initCatalogUI(vi.fn())
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(document.getElementById('catalog-search').value).toBe('satellite')
+
+    document.getElementById('catalog-toggle-btn').click()
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(mockGetCogImages).toHaveBeenCalledWith(expect.objectContaining({ search: 'satellite' }))
   })
 })


### PR DESCRIPTION
## Summary
- 카탈로그 필터/정렬 변경 시 `history.replaceState`로 URL 쿼리스트링 즉시 업데이트
- 페이지 초기화 시 URL 파라미터를 읽어 필터/정렬 UI 상태 복원
- 기본값(created_at desc, 빈 필터 등)은 URL에서 제거하여 간결하게 유지
- 지원 파라미터: tag, sensor, region, source, year, sortBy, sortOrder, search, likedOnly, myImagesOnly

## Test plan
- [x] 기존 테스트 374개 전체 통과
- [x] URL 쿼리스트링 동기화 테스트 8개 추가 (필터 적용/복원/초기화/다중 필터/검색어 등)
- [ ] 브라우저에서 필터 변경 후 URL 업데이트 확인
- [ ] URL에 필터 파라미터 포함하여 접근 시 상태 복원 확인

closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)