### PR TITLE
feat: 카탈로그 현재 뷰어 로드 영상 카드 활성 표시

### DIFF
--- a/index.html
+++ b/index.html
@@ -888,6 +888,11 @@
       transition: border-color 0.15s, background 0.15s;
     }
 
+    .catalog-card--active {
+      border-color: #667eea;
+      background: #eef0ff;
+    }
+
     .catalog-card:hover {
       border-color: #667eea;
       background: #f8f9ff;

--- a/src/catalogUI.js
+++ b/src/catalogUI.js
@@ -128,6 +128,7 @@ export function initCatalogUI(onSelectCog) {
   let sortBy = 'created_at'
   let sortOrder = DEFAULT_SORT_ORDERS[sortBy]
   let watchlistAbort = null
+  let activeCardId = null
 
   function updateSortOrderBtn() {
     sortOrderBtn.textContent = sortOrder === 'asc' ? '↑' : '↓'
@@ -377,7 +378,7 @@ export function initCatalogUI(onSelectCog) {
 
     data.forEach(item => {
       const card = document.createElement('div')
-      card.className = 'catalog-card'
+      card.className = 'catalog-card' + (activeCardId === item.id ? ' catalog-card--active' : '')
 
       const thumbHtml = item.thumbnail_url
         ? `<img src="${escapeHtml(item.thumbnail_url)}" class="catalog-card-thumb" alt="${escapeHtml(item.title || '영상')}" loading="lazy" onerror="this.style.display='none'">`
@@ -523,6 +524,11 @@ export function initCatalogUI(onSelectCog) {
           tagFilter.dispatchEvent(new Event('input'))
           return
         }
+        // 이전 활성 카드 해제, 새 카드 활성화
+        const prevActive = listEl.querySelector('.catalog-card--active')
+        if (prevActive) prevActive.classList.remove('catalog-card--active')
+        card.classList.add('catalog-card--active')
+        activeCardId = item.id
         panel.classList.remove('open')
         incrementViewCount(item.id)
         onSelectCog(item.url, item)

--- a/tests/unit/catalogUI.test.js
+++ b/tests/unit/catalogUI.test.js
@@ -1340,3 +1340,79 @@ describe('catalogUI URL query string sync', () => {
     expect(mockGetCogImages).toHaveBeenCalledWith(expect.objectContaining({ search: 'satellite' }))
   })
 })
+
+describe('catalogUI active card', () => {
+  const items = [
+    { id: 'a1', title: 'First', url: 'http://a1.tif', crs: 'EPSG:4326', created_at: '2024-01-01' },
+    { id: 'a2', title: 'Second', url: 'http://a2.tif', crs: 'EPSG:4326', created_at: '2024-01-02' },
+  ]
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    setupDOM()
+    mockGetSession.mockResolvedValue(null)
+    mockGetLikeStates.mockResolvedValue(new Map())
+    mockGetWatchlistedImageIds.mockResolvedValue(new Set())
+    mockGetCogImages.mockResolvedValue({ data: items, totalCount: 2, error: null })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    document.body.innerHTML = ''
+    window.history.replaceState(null, '', '/')
+  })
+
+  it('카드 클릭 시 catalog-card--active 클래스 적용', async () => {
+    const onSelect = vi.fn()
+    initCatalogUI(onSelect)
+    await vi.advanceTimersByTimeAsync(10)
+
+    document.getElementById('catalog-toggle-btn').click()
+    await vi.advanceTimersByTimeAsync(10)
+
+    const cards = document.querySelectorAll('.catalog-card')
+    expect(cards.length).toBe(2)
+
+    cards[0].click()
+    expect(cards[0].classList.contains('catalog-card--active')).toBe(true)
+    expect(cards[1].classList.contains('catalog-card--active')).toBe(false)
+  })
+
+  it('다른 카드 클릭 시 이전 카드 활성 해제', async () => {
+    const onSelect = vi.fn()
+    initCatalogUI(onSelect)
+    await vi.advanceTimersByTimeAsync(10)
+
+    document.getElementById('catalog-toggle-btn').click()
+    await vi.advanceTimersByTimeAsync(10)
+
+    const cards = document.querySelectorAll('.catalog-card')
+    cards[0].click()
+    cards[1].click()
+    expect(cards[0].classList.contains('catalog-card--active')).toBe(false)
+    expect(cards[1].classList.contains('catalog-card--active')).toBe(true)
+  })
+
+  it('패널 재오픈 시 활성 카드 유지', async () => {
+    const onSelect = vi.fn()
+    initCatalogUI(onSelect)
+    await vi.advanceTimersByTimeAsync(10)
+
+    document.getElementById('catalog-toggle-btn').click()
+    await vi.advanceTimersByTimeAsync(10)
+
+    const cards = document.querySelectorAll('.catalog-card')
+    cards[0].click()
+
+    // 패널 닫기 후 다시 열기
+    document.getElementById('catalog-toggle-btn').click()
+    await vi.advanceTimersByTimeAsync(10)
+    document.getElementById('catalog-toggle-btn').click()
+    await vi.advanceTimersByTimeAsync(10)
+
+    const refreshedCards = document.querySelectorAll('.catalog-card')
+    expect(refreshedCards[0].classList.contains('catalog-card--active')).toBe(true)
+    expect(refreshedCards[1].classList.contains('catalog-card--active')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- 카탈로그 카드 클릭 시 `catalog-card--active` 클래스 적용으로 현재 뷰어 로드 영상 시각 구분
- 패널 닫기/재오픈 시에도 활성 카드 상태 유지
- 다른 카드 선택 시 이전 활성 상태 자동 해제

closes #291

## Test plan
- [x] 카드 클릭 시 active 클래스 적용 테스트
- [x] 다른 카드 클릭 시 이전 카드 active 해제 테스트
- [x] 패널 재오픈 시 활성 카드 유지 테스트
- [x] 기존 95개 테스트 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)