### PR TITLE
feat: 카탈로그 카드 '지도로 이동' 버튼 추가 (bbox 기반)

### DIFF
--- a/src/catalogUI.js
+++ b/src/catalogUI.js
@@ -493,6 +493,18 @@ export function initCatalogUI(onSelectCog) {
         }
       }
 
+      // 지도로 이동 버튼 (bbox가 있는 경우만 표시)
+      if (item.bbox) {
+        const fitBboxBtn = document.createElement('button')
+        fitBboxBtn.className = 'catalog-fit-bbox-btn'
+        fitBboxBtn.textContent = '🗺️ 지도로 이동'
+        fitBboxBtn.addEventListener('click', (e) => {
+          e.stopPropagation()
+          document.dispatchEvent(new CustomEvent('catalog-fit-bbox', { detail: { bbox: item.bbox } }))
+        })
+        card.appendChild(fitBboxBtn)
+      }
+
       // 공유 버튼 (모든 사용자에게 표시)
       const shareBtn = document.createElement('button')
       shareBtn.className = 'catalog-share-btn'

--- a/src/main.js
+++ b/src/main.js
@@ -484,6 +484,15 @@ const loadCOG = async (rawUrl, catalogMeta = null, overrideBandInfo = null, { sk
   import('./catalogUI.js').then(m => m.initCatalogUI((url, catalogItem) => loadCOG(url, catalogItem))).catch(console.error)
   import('./watchlistUI.js').then(m => m.initWatchlistUI((url, catalogItem) => loadCOG(url, catalogItem))).catch(console.error)
 
+  // 카탈로그 카드 '지도로 이동' 버튼 이벤트 핸들러
+  document.addEventListener('catalog-fit-bbox', (e) => {
+    const bbox = e.detail?.bbox
+    if (!bbox || bbox.length !== 4) return
+    const extent = transformExtent(bbox, 'EPSG:4326', map.getView().getProjection())
+    const pad = window.innerWidth <= 768 ? 20 : 50
+    map.getView().fit(extent, { padding: [pad, pad, pad, pad], duration: 500 })
+  })
+
   // STAC UI 초기화
   import('./stacUI.js').then(m => m.initStacUI(
     (url) => loadCOG(url),

--- a/tests/unit/catalogUI.test.js
+++ b/tests/unit/catalogUI.test.js
@@ -1416,3 +1416,53 @@ describe('catalogUI active card', () => {
     expect(refreshedCards[1].classList.contains('catalog-card--active')).toBe(false)
   })
 })
+
+describe('catalogUI fit-bbox button', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupDOM()
+    mockGetSession.mockResolvedValue({ user: null })
+    mockOnAuthStateChange.mockImplementation(() => {})
+    mockGetLikeStates.mockResolvedValue(new Map())
+    mockGetWatchlistedImageIds.mockResolvedValue(new Set())
+  })
+
+  async function openPanelWithItems(items) {
+    mockGetCogImages.mockResolvedValue({ data: items, totalCount: items.length, error: null })
+    const onSelect = vi.fn()
+    initCatalogUI(onSelect)
+    await new Promise(r => setTimeout(r, 10))
+    document.getElementById('catalog-toggle-btn').click()
+    await new Promise(r => setTimeout(r, 10))
+    return onSelect
+  }
+
+  it('bbox가 있는 카드에 지도로 이동 버튼이 표시된다', async () => {
+    await openPanelWithItems([
+      { id: '1', url: 'http://a.tif', title: 'With bbox', bbox: [1, 2, 3, 4] },
+    ])
+    const btn = document.querySelector('.catalog-fit-bbox-btn')
+    expect(btn).not.toBeNull()
+    expect(btn.textContent).toContain('지도로 이동')
+  })
+
+  it('bbox가 없는 카드에는 지도로 이동 버튼이 표시되지 않는다', async () => {
+    await openPanelWithItems([
+      { id: '2', url: 'http://b.tif', title: 'No bbox', bbox: null },
+    ])
+    const btn = document.querySelector('.catalog-fit-bbox-btn')
+    expect(btn).toBeNull()
+  })
+
+  it('버튼 클릭 시 catalog-fit-bbox 이벤트를 발행한다', async () => {
+    await openPanelWithItems([
+      { id: '3', url: 'http://c.tif', title: 'Test', bbox: [10, 20, 30, 40] },
+    ])
+    const handler = vi.fn()
+    document.addEventListener('catalog-fit-bbox', handler)
+    document.querySelector('.catalog-fit-bbox-btn').click()
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler.mock.calls[0][0].detail).toEqual({ bbox: [10, 20, 30, 40] })
+    document.removeEventListener('catalog-fit-bbox', handler)
+  })
+})


### PR DESCRIPTION
## Summary
- bbox가 있는 카탈로그 카드에 '🗺️ 지도로 이동' 버튼 추가
- 클릭 시 `catalog-fit-bbox` 커스텀 이벤트 발행 → `main.js`에서 `map.getView().fit()`으로 지도 뷰 이동 (duration: 500ms)
- bbox가 없는 카드에는 버튼 미표시

## Changes
- `src/catalogUI.js`: 카드 렌더링 시 bbox 존재 여부에 따라 버튼 조건부 렌더링
- `src/main.js`: `catalog-fit-bbox` 이벤트 리스너 추가 (`transformExtent`로 좌표 변환 후 fit)
- `tests/unit/catalogUI.test.js`: 단위 테스트 3건 추가

## Test plan
- [ ] bbox가 있는 카드에 '지도로 이동' 버튼 표시 확인
- [ ] bbox가 없는 카드에 버튼 미표시 확인
- [ ] 버튼 클릭 시 지도 뷰가 해당 영상 범위로 이동 확인
- [ ] `npx vitest run tests/unit/catalogUI.test.js` 98개 테스트 전체 통과

closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)