### PR TITLE
feat: 카탈로그 카드 hover 시 지도에 bbox 하이라이트 표시

### DIFF
--- a/src/catalogUI.js
+++ b/src/catalogUI.js
@@ -529,6 +529,16 @@ export function initCatalogUI(onSelectCog) {
       viewCountEl.textContent = `👁 ${item.view_count || 0}`
       card.appendChild(viewCountEl)
 
+      // hover 시 bbox 하이라이트 표시
+      if (item.bbox) {
+        card.addEventListener('mouseenter', () => {
+          document.dispatchEvent(new CustomEvent('catalog-card-mouseenter', { detail: { bbox: item.bbox } }))
+        })
+        card.addEventListener('mouseleave', () => {
+          document.dispatchEvent(new CustomEvent('catalog-card-mouseleave'))
+        })
+      }
+
       card.addEventListener('click', (e) => {
         if (e.target.classList.contains('catalog-tag')) {
           e.stopPropagation()

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,11 @@ import { Map, View } from 'ol'
 import LayerGroup from 'ol/layer/Group'
 import { defaults as defaultControls } from 'ol/control'
 import { transform, transformExtent } from 'ol/proj'
+import VectorLayer from 'ol/layer/Vector'
+import VectorSource from 'ol/source/Vector'
+import Feature from 'ol/Feature'
+import { fromExtent } from 'ol/geom/Polygon'
+import { Style, Stroke, Fill } from 'ol/style'
 // @conaonda/ol-cog-layers: 동적 import로 초기 번들에서 제외
 const _cogLayers = () => import('@conaonda/ol-cog-layers')
 import { proxyCogUrl } from './proxy.js'
@@ -483,6 +488,30 @@ const loadCOG = async (rawUrl, catalogMeta = null, overrideBandInfo = null, { sk
 
   import('./catalogUI.js').then(m => m.initCatalogUI((url, catalogItem) => loadCOG(url, catalogItem))).catch(console.error)
   import('./watchlistUI.js').then(m => m.initWatchlistUI((url, catalogItem) => loadCOG(url, catalogItem))).catch(console.error)
+
+  // 카탈로그 카드 hover bbox 하이라이트 레이어
+  const highlightSource = new VectorSource()
+  const highlightLayer = new VectorLayer({
+    source: highlightSource,
+    style: new Style({
+      stroke: new Stroke({ color: '#667eea', width: 2 }),
+      fill: new Fill({ color: 'rgba(102,126,234,0.15)' })
+    }),
+    zIndex: 200
+  })
+  map.addLayer(highlightLayer)
+
+  document.addEventListener('catalog-card-mouseenter', (e) => {
+    const bbox = e.detail?.bbox
+    if (!bbox || bbox.length !== 4) return
+    highlightSource.clear()
+    const extent = transformExtent(bbox, 'EPSG:4326', map.getView().getProjection())
+    highlightSource.addFeature(new Feature(fromExtent(extent)))
+  })
+
+  document.addEventListener('catalog-card-mouseleave', () => {
+    highlightSource.clear()
+  })
 
   // 카탈로그 카드 '지도로 이동' 버튼 이벤트 핸들러
   document.addEventListener('catalog-fit-bbox', (e) => {

--- a/tests/unit/catalogUI.test.js
+++ b/tests/unit/catalogUI.test.js
@@ -1466,3 +1466,61 @@ describe('catalogUI fit-bbox button', () => {
     document.removeEventListener('catalog-fit-bbox', handler)
   })
 })
+
+describe('catalogUI hover bbox highlight', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupDOM()
+    mockGetSession.mockResolvedValue({ user: null })
+    mockOnAuthStateChange.mockImplementation(() => {})
+    mockGetLikeStates.mockResolvedValue(new Map())
+    mockGetWatchlistedImageIds.mockResolvedValue(new Set())
+  })
+
+  async function openPanelWithItems(items) {
+    mockGetCogImages.mockResolvedValue({ data: items, totalCount: items.length, error: null })
+    const onSelect = vi.fn()
+    initCatalogUI(onSelect)
+    await new Promise(r => setTimeout(r, 10))
+    document.getElementById('catalog-toggle-btn').click()
+    await new Promise(r => setTimeout(r, 10))
+    return onSelect
+  }
+
+  it('bbox가 있는 카드에 mouseenter 시 catalog-card-mouseenter 이벤트를 발행한다', async () => {
+    await openPanelWithItems([
+      { id: '1', url: 'http://a.tif', title: 'With bbox', bbox: [1, 2, 3, 4] },
+    ])
+    const handler = vi.fn()
+    document.addEventListener('catalog-card-mouseenter', handler)
+    const card = document.querySelector('.catalog-card')
+    card.dispatchEvent(new MouseEvent('mouseenter'))
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler.mock.calls[0][0].detail).toEqual({ bbox: [1, 2, 3, 4] })
+    document.removeEventListener('catalog-card-mouseenter', handler)
+  })
+
+  it('bbox가 있는 카드에서 mouseleave 시 catalog-card-mouseleave 이벤트를 발행한다', async () => {
+    await openPanelWithItems([
+      { id: '1', url: 'http://a.tif', title: 'With bbox', bbox: [1, 2, 3, 4] },
+    ])
+    const handler = vi.fn()
+    document.addEventListener('catalog-card-mouseleave', handler)
+    const card = document.querySelector('.catalog-card')
+    card.dispatchEvent(new MouseEvent('mouseleave'))
+    expect(handler).toHaveBeenCalledTimes(1)
+    document.removeEventListener('catalog-card-mouseleave', handler)
+  })
+
+  it('bbox가 없는 카드에 mouseenter 시 이벤트를 발행하지 않는다', async () => {
+    await openPanelWithItems([
+      { id: '2', url: 'http://b.tif', title: 'No bbox', bbox: null },
+    ])
+    const handler = vi.fn()
+    document.addEventListener('catalog-card-mouseenter', handler)
+    const card = document.querySelector('.catalog-card')
+    card.dispatchEvent(new MouseEvent('mouseenter'))
+    expect(handler).not.toHaveBeenCalled()
+    document.removeEventListener('catalog-card-mouseenter', handler)
+  })
+})


### PR DESCRIPTION
## Summary
- 카탈로그 카드에 mouseenter 시 해당 영상의 bbox를 지도 위에 반투명 사각형(VectorLayer)으로 표시
- mouseleave 시 하이라이트 제거
- bbox가 없는 카드는 아무 동작 없음

closes #299

## Test plan
- [x] bbox 있는 카드 hover 시 `catalog-card-mouseenter` 이벤트 발행 테스트
- [x] bbox 있는 카드 mouseleave 시 `catalog-card-mouseleave` 이벤트 발행 테스트
- [x] bbox 없는 카드 hover 시 이벤트 미발행 테스트
- [x] 기존 테스트 385개 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)