### PR TITLE
feat: 카탈로그 검색어 하이라이팅 (카드 제목/설명에 검색어 강조 표시)

### DIFF
--- a/index.html
+++ b/index.html
@@ -915,6 +915,14 @@
       white-space: nowrap;
     }
 
+    .catalog-card-title mark,
+    .catalog-card-desc mark {
+      background-color: #fef08a;
+      color: inherit;
+      padding: 0 1px;
+      border-radius: 2px;
+    }
+
     .catalog-card-meta {
       font-size: 0.7rem;
       color: #999;

--- a/src/catalogUI.js
+++ b/src/catalogUI.js
@@ -407,8 +407,8 @@ export function initCatalogUI(onSelectCog) {
 
       card.innerHTML = `
         ${thumbHtml}
-        <div class="catalog-card-title">${sourceBadge} ${escapeHtml(item.title || '제목 없음')}</div>
-        <div class="catalog-card-desc">${escapeHtml(item.description || '')}</div>
+        <div class="catalog-card-title">${sourceBadge} ${highlightText(item.title || '제목 없음', searchTerm)}</div>
+        <div class="catalog-card-desc">${highlightText(item.description || '', searchTerm)}</div>
         ${tagsHtml}
         ${capturedAtHtml}
         ${resolutionHtml}
@@ -569,6 +569,14 @@ function escapeHtml(str) {
   const div = document.createElement('div')
   div.textContent = str
   return div.innerHTML
+}
+
+function highlightText(text, query) {
+  if (!query) return escapeHtml(text)
+  const escaped = escapeHtml(text)
+  const escapedQuery = escapeHtml(query)
+  const regex = new RegExp(`(${escapedQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi')
+  return escaped.replace(regex, '<mark>$1</mark>')
 }
 
 function formatDate(iso) {

--- a/tests/unit/catalogUI.test.js
+++ b/tests/unit/catalogUI.test.js
@@ -1524,3 +1524,74 @@ describe('catalogUI hover bbox highlight', () => {
     document.removeEventListener('catalog-card-mouseenter', handler)
   })
 })
+
+describe('catalogUI search highlighting', () => {
+  const TEST_USER_ID = 'user-123'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupDOM()
+    mockGetSession.mockResolvedValue({ user: { id: TEST_USER_ID } })
+    mockOnAuthStateChange.mockImplementation(() => {})
+    mockGetLikeStates.mockResolvedValue(new Map())
+    mockGetWatchlistedImageIds.mockResolvedValue(new Set())
+  })
+
+  async function openPanelWithSearch(items, query) {
+    mockGetCogImages.mockResolvedValue({ data: items, totalCount: items.length, error: null })
+    const onSelect = vi.fn()
+    initCatalogUI(onSelect)
+    await new Promise(r => setTimeout(r, 10))
+    document.getElementById('catalog-toggle-btn').click()
+    await new Promise(r => setTimeout(r, 10))
+    if (query) {
+      const searchInput = document.getElementById('catalog-search')
+      searchInput.value = query
+      searchInput.dispatchEvent(new Event('input'))
+      await new Promise(r => setTimeout(r, 350))
+    }
+    return onSelect
+  }
+
+  it('highlights search term in card title and description', async () => {
+    await openPanelWithSearch(
+      [{ id: '1', user_id: TEST_USER_ID, title: 'Sentinel 위성 영상', description: 'Sentinel-2 데이터입니다', tags: [], created_at: '2026-01-01' }],
+      'Sentinel',
+    )
+    const card = document.querySelector('.catalog-card')
+    const title = card.querySelector('.catalog-card-title')
+    const desc = card.querySelector('.catalog-card-desc')
+    expect(title.querySelectorAll('mark')).toHaveLength(1)
+    expect(title.querySelector('mark').textContent).toBe('Sentinel')
+    expect(desc.querySelectorAll('mark')).toHaveLength(1)
+    expect(desc.querySelector('mark').textContent).toBe('Sentinel')
+  })
+
+  it('highlights case-insensitively', async () => {
+    await openPanelWithSearch(
+      [{ id: '1', user_id: TEST_USER_ID, title: 'LANDSAT Image', description: 'landsat data', tags: [], created_at: '2026-01-01' }],
+      'landsat',
+    )
+    const card = document.querySelector('.catalog-card')
+    const title = card.querySelector('.catalog-card-title')
+    expect(title.querySelector('mark').textContent).toBe('LANDSAT')
+  })
+
+  it('does not highlight when search is empty', async () => {
+    await openPanelWithSearch(
+      [{ id: '1', user_id: TEST_USER_ID, title: 'Test Image', description: 'desc', tags: [], created_at: '2026-01-01' }],
+      '',
+    )
+    const card = document.querySelector('.catalog-card')
+    expect(card.querySelector('mark')).toBeNull()
+  })
+
+  it('escapes HTML in search term to prevent XSS', async () => {
+    await openPanelWithSearch(
+      [{ id: '1', user_id: TEST_USER_ID, title: '<script>alert("xss")</script>', description: 'safe', tags: [], created_at: '2026-01-01' }],
+      '<script>',
+    )
+    const card = document.querySelector('.catalog-card')
+    expect(card.querySelector('script')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- 카탈로그 검색어 입력 시 카드 제목/설명에서 일치하는 부분을 `<mark>` 태그로 강조 표시
- 대소문자 구분 없이 매칭, XSS 방어 (escapeHtml 후 하이라이팅 적용)
- `highlightText()` 유틸 함수 추가 및 mark 태그 CSS 스타일 추가

## Changes
- `src/catalogUI.js`: `highlightText()` 함수 추가, 카드 렌더링에 적용
- `index.html`: `<mark>` 태그 CSS 스타일 추가
- `tests/unit/catalogUI.test.js`: 검색어 하이라이팅 단위 테스트 4건 추가

## Test plan
- [x] 검색어 입력 시 카드 제목/설명에서 일치 부분이 시각적으로 강조됨
- [x] 검색어 없으면 강조 없음
- [x] XSS 안전 (사용자 입력이 HTML로 해석되지 않음)
- [x] 기존 테스트 모두 통과 (105/105)
- [x] 신규 단위 테스트 4건 추가 및 통과

closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)