### PR TITLE
feat: 카탈로그 카드 그리드/리스트 뷰 전환 버튼 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -879,6 +879,55 @@
       padding: 0 0.75rem;
     }
 
+    /* 뷰 토글 버튼 */
+    .catalog-view-toggle {
+      display: flex;
+      gap: 0.25rem;
+      padding: 0.25rem 0.75rem;
+    }
+
+    .catalog-view-btn {
+      padding: 0.25rem 0.5rem;
+      border: 1px solid #d1d5db;
+      border-radius: 4px;
+      background: white;
+      cursor: pointer;
+      font-size: 0.9rem;
+      line-height: 1;
+      color: #6b7280;
+      transition: background 0.15s, border-color 0.15s;
+    }
+
+    .catalog-view-btn:hover {
+      border-color: #667eea;
+      color: #667eea;
+    }
+
+    .catalog-view-btn.active {
+      background: #667eea;
+      border-color: #667eea;
+      color: white;
+    }
+
+    /* 리스트 뷰 */
+    .catalog-list--list-view .catalog-card-body {
+      display: flex;
+      gap: 0.5rem;
+      align-items: flex-start;
+    }
+
+    .catalog-list--list-view .catalog-card-thumb {
+      width: 60px;
+      max-height: 60px;
+      flex-shrink: 0;
+      margin-bottom: 0;
+    }
+
+    .catalog-list--list-view .catalog-card-info {
+      flex: 1;
+      min-width: 0;
+    }
+
     .catalog-card {
       padding: 0.75rem;
       border: 1px solid #e5e7eb;

--- a/src/catalogUI.js
+++ b/src/catalogUI.js
@@ -122,6 +122,36 @@ export function initCatalogUI(onSelectCog) {
   totalCountEl.className = 'catalog-total-count'
   pageSizeContainer.parentNode.insertBefore(totalCountEl, pageSizeContainer.nextSibling)
 
+  // 그리드/리스트 뷰 토글 버튼
+  const viewToggleContainer = document.createElement('div')
+  viewToggleContainer.className = 'catalog-view-toggle'
+  viewToggleContainer.innerHTML = `
+    <button type="button" class="catalog-view-btn" data-view="grid" aria-label="그리드 뷰" title="그리드 뷰">⊞</button>
+    <button type="button" class="catalog-view-btn" data-view="list" aria-label="리스트 뷰" title="리스트 뷰">≡</button>
+  `
+  searchInput.parentNode.insertBefore(viewToggleContainer, searchInput.nextSibling)
+  // 필터 컨테이너를 뷰 토글 뒤로 이동
+  viewToggleContainer.parentNode.insertBefore(filterContainer, viewToggleContainer.nextSibling)
+
+  let viewMode = localStorage.getItem('catalog-view-mode') || 'grid'
+
+  function applyViewMode() {
+    listEl.classList.toggle('catalog-list--list-view', viewMode === 'list')
+    viewToggleContainer.querySelectorAll('.catalog-view-btn').forEach(btn => {
+      btn.classList.toggle('active', btn.dataset.view === viewMode)
+    })
+  }
+
+  viewToggleContainer.addEventListener('click', (e) => {
+    const btn = e.target.closest('.catalog-view-btn')
+    if (!btn) return
+    viewMode = btn.dataset.view
+    localStorage.setItem('catalog-view-mode', viewMode)
+    applyViewMode()
+  })
+
+  applyViewMode()
+
   let pageSize = DEFAULT_PAGE_SIZE
   let currentPage = 0
   let searchTerm = ''
@@ -406,13 +436,17 @@ export function initCatalogUI(onSelectCog) {
         : ''
 
       card.innerHTML = `
-        ${thumbHtml}
-        <div class="catalog-card-title">${sourceBadge} ${highlightText(item.title || '제목 없음', searchTerm)}</div>
-        <div class="catalog-card-desc">${highlightText(item.description || '', searchTerm)}</div>
-        ${tagsHtml}
-        ${capturedAtHtml}
-        ${resolutionHtml}
-        <div class="catalog-card-meta">${metaParts.filter(Boolean).join(' | ')}</div>
+        <div class="catalog-card-body">
+          ${thumbHtml}
+          <div class="catalog-card-info">
+            <div class="catalog-card-title">${sourceBadge} ${highlightText(item.title || '제목 없음', searchTerm)}</div>
+            <div class="catalog-card-desc">${highlightText(item.description || '', searchTerm)}</div>
+            ${tagsHtml}
+            ${capturedAtHtml}
+            ${resolutionHtml}
+            <div class="catalog-card-meta">${metaParts.filter(Boolean).join(' | ')}</div>
+          </div>
+        </div>
       `
 
       // 좋아요 + 관심목록 버튼 (로그인 시만 표시)

--- a/tests/unit/catalogUI.test.js
+++ b/tests/unit/catalogUI.test.js
@@ -1595,3 +1595,88 @@ describe('catalogUI search highlighting', () => {
     expect(card.querySelector('script')).toBeNull()
   })
 })
+
+describe('catalogUI view toggle (grid/list)', () => {
+  const TEST_USER_ID = 'user-123'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    setupDOM()
+    mockGetSession.mockResolvedValue({ user: { id: TEST_USER_ID } })
+    mockOnAuthStateChange.mockImplementation(() => {})
+    mockGetLikeStates.mockResolvedValue(new Map())
+    mockGetWatchlistedImageIds.mockResolvedValue(new Set())
+  })
+
+  async function openPanelWithItems(items) {
+    mockGetCogImages.mockResolvedValue({ data: items, totalCount: items.length, error: null })
+    const onSelect = vi.fn()
+    initCatalogUI(onSelect)
+    await new Promise(r => setTimeout(r, 10))
+    document.getElementById('catalog-toggle-btn').click()
+    await new Promise(r => setTimeout(r, 10))
+    return onSelect
+  }
+
+  it('renders view toggle buttons', async () => {
+    await openPanelWithItems([])
+    const btns = document.querySelectorAll('.catalog-view-btn')
+    expect(btns).toHaveLength(2)
+    expect(btns[0].dataset.view).toBe('grid')
+    expect(btns[1].dataset.view).toBe('list')
+  })
+
+  it('defaults to grid view with active class', async () => {
+    await openPanelWithItems([])
+    const gridBtn = document.querySelector('.catalog-view-btn[data-view="grid"]')
+    const listBtn = document.querySelector('.catalog-view-btn[data-view="list"]')
+    expect(gridBtn.classList.contains('active')).toBe(true)
+    expect(listBtn.classList.contains('active')).toBe(false)
+    expect(document.getElementById('catalog-list').classList.contains('catalog-list--list-view')).toBe(false)
+  })
+
+  it('switches to list view on click', async () => {
+    await openPanelWithItems([])
+    const listBtn = document.querySelector('.catalog-view-btn[data-view="list"]')
+    listBtn.click()
+    expect(listBtn.classList.contains('active')).toBe(true)
+    expect(document.getElementById('catalog-list').classList.contains('catalog-list--list-view')).toBe(true)
+  })
+
+  it('saves view mode to localStorage', async () => {
+    await openPanelWithItems([])
+    const listBtn = document.querySelector('.catalog-view-btn[data-view="list"]')
+    listBtn.click()
+    expect(localStorage.getItem('catalog-view-mode')).toBe('list')
+  })
+
+  it('restores view mode from localStorage', async () => {
+    localStorage.setItem('catalog-view-mode', 'list')
+    await openPanelWithItems([])
+    const listEl = document.getElementById('catalog-list')
+    expect(listEl.classList.contains('catalog-list--list-view')).toBe(true)
+    const listBtn = document.querySelector('.catalog-view-btn[data-view="list"]')
+    expect(listBtn.classList.contains('active')).toBe(true)
+  })
+
+  it('list view cards have catalog-card-body wrapper', async () => {
+    await openPanelWithItems([
+      { id: '1', user_id: TEST_USER_ID, title: 'Test', description: 'desc', tags: [], created_at: '2026-01-01', thumbnail_url: 'http://example.com/thumb.jpg' },
+    ])
+    const body = document.querySelector('.catalog-card-body')
+    expect(body).not.toBeNull()
+    expect(body.querySelector('.catalog-card-info')).not.toBeNull()
+  })
+
+  it('switches back to grid view', async () => {
+    await openPanelWithItems([])
+    const listBtn = document.querySelector('.catalog-view-btn[data-view="list"]')
+    const gridBtn = document.querySelector('.catalog-view-btn[data-view="grid"]')
+    listBtn.click()
+    gridBtn.click()
+    expect(gridBtn.classList.contains('active')).toBe(true)
+    expect(document.getElementById('catalog-list').classList.contains('catalog-list--list-view')).toBe(false)
+    expect(localStorage.getItem('catalog-view-mode')).toBe('grid')
+  })
+})


### PR DESCRIPTION
## Summary
- 카탈로그 패널 상단에 그리드(⊞)/리스트(≡) 뷰 토글 버튼 추가
- 리스트 뷰: 썸네일(소형) + 제목/설명/메타데이터 수평 배치
- localStorage에 뷰 모드 저장/복원 (새로고침 후에도 유지)
- 기존 카드 기능(클릭, 좋아요, 공유, 관심목록, 태그, hover bbox) 모두 동작

## Test plan
- [x] 뷰 토글 버튼 렌더링 테스트
- [x] 그리드 → 리스트 전환 테스트
- [x] 리스트 → 그리드 전환 테스트
- [x] localStorage 저장/복원 테스트
- [x] 카드 body wrapper 구조 테스트
- [x] 기존 105개 테스트 전체 통과 확인

closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)