### PR TITLE
feat: 카탈로그 활성 필터 칩(active filter chips) 표시

### DIFF
--- a/index.html
+++ b/index.html
@@ -1414,6 +1414,42 @@
       background: #e5e7eb;
     }
 
+    /* Active filter chips */
+    .catalog-active-filters {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.3rem;
+      padding: 0 0.75rem 0.5rem;
+    }
+
+    .catalog-filter-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      padding: 0.2rem 0.5rem;
+      background: #eef2ff;
+      border: 1px solid #c7d2fe;
+      border-radius: 999px;
+      font-size: 0.7rem;
+      color: #4338ca;
+      white-space: nowrap;
+    }
+
+    .catalog-filter-chip-remove {
+      background: none;
+      border: none;
+      padding: 0;
+      margin: 0;
+      cursor: pointer;
+      font-size: 0.8rem;
+      color: #6366f1;
+      line-height: 1;
+    }
+
+    .catalog-filter-chip-remove:hover {
+      color: #dc2626;
+    }
+
     /* Catalog card thumbnail */
     .catalog-card-thumb {
       width: 100%;

--- a/src/catalogUI.js
+++ b/src/catalogUI.js
@@ -152,6 +152,13 @@ export function initCatalogUI(onSelectCog) {
 
   applyViewMode()
 
+  // 활성 필터 칩 영역
+  const activeFiltersContainer = document.createElement('div')
+  activeFiltersContainer.id = 'catalog-active-filters'
+  activeFiltersContainer.className = 'catalog-active-filters'
+  activeFiltersContainer.style.display = 'none'
+  listEl.parentNode.insertBefore(activeFiltersContainer, listEl)
+
   let pageSize = DEFAULT_PAGE_SIZE
   let currentPage = 0
   let searchTerm = ''
@@ -221,6 +228,7 @@ export function initCatalogUI(onSelectCog) {
   }
 
   readUrlParams()
+  renderActiveFilterChips()
 
   let debounceTimer = null
   let isUserLoggedIn = false
@@ -277,6 +285,43 @@ export function initCatalogUI(onSelectCog) {
     resetBtn.style.display = hasActiveFilter() ? '' : 'none'
   }
 
+  function renderActiveFilterChips() {
+    activeFiltersContainer.innerHTML = ''
+    const chips = []
+
+    if (searchInput.value.trim()) chips.push({ label: `검색: ${searchInput.value.trim()}`, clear: () => { searchInput.value = ''; searchTerm = '' } })
+    if (sourceFilter.value) chips.push({ label: `출처: ${sourceFilter.value === 'stac' ? 'STAC' : '수동 등록'}`, clear: () => { sourceFilter.value = '' } })
+    if (tagFilter.value.trim()) chips.push({ label: `태그: ${tagFilter.value.trim()}`, clear: () => { tagFilter.value = '' } })
+    if (yearFilter.value) chips.push({ label: `연도: ${yearFilter.value}`, clear: () => { yearFilter.value = '' } })
+    if (onlyMineCheckbox.checked) chips.push({ label: '내 등록만', clear: () => { onlyMineCheckbox.checked = false } })
+    if (likedOnlyCheckbox.checked) chips.push({ label: '좋아요만', clear: () => { likedOnlyCheckbox.checked = false } })
+
+    activeFiltersContainer.style.display = chips.length > 0 ? '' : 'none'
+
+    chips.forEach(({ label, clear }) => {
+      const chip = document.createElement('span')
+      chip.className = 'catalog-filter-chip'
+      chip.textContent = label
+
+      const removeBtn = document.createElement('button')
+      removeBtn.className = 'catalog-filter-chip-remove'
+      removeBtn.type = 'button'
+      removeBtn.innerHTML = '&times;'
+      removeBtn.setAttribute('aria-label', `${label} 필터 해제`)
+      removeBtn.addEventListener('click', (e) => {
+        e.stopPropagation()
+        clear()
+        currentPage = 0
+        updateResetBtnVisibility()
+        renderActiveFilterChips()
+        loadPage()
+      })
+
+      chip.appendChild(removeBtn)
+      activeFiltersContainer.appendChild(chip)
+    })
+  }
+
   resetBtn.addEventListener('click', () => {
     searchInput.value = ''
     tagFilter.value = ''
@@ -289,6 +334,7 @@ export function initCatalogUI(onSelectCog) {
     searchTerm = ''
     currentPage = 0
     updateResetBtnVisibility()
+    renderActiveFilterChips()
     loadPage()
   })
 
@@ -298,6 +344,7 @@ export function initCatalogUI(onSelectCog) {
       searchTerm = searchInput.value.trim()
       currentPage = 0
       updateResetBtnVisibility()
+      renderActiveFilterChips()
       loadPage()
     }, 300)
   }
@@ -329,11 +376,13 @@ export function initCatalogUI(onSelectCog) {
   onlyMineCheckbox.addEventListener('change', () => {
     currentPage = 0
     updateResetBtnVisibility()
+    renderActiveFilterChips()
     loadPage()
   })
   likedOnlyCheckbox.addEventListener('change', () => {
     currentPage = 0
     updateResetBtnVisibility()
+    renderActiveFilterChips()
     loadPage()
   })
 

--- a/tests/unit/catalogUI.test.js
+++ b/tests/unit/catalogUI.test.js
@@ -1680,3 +1680,108 @@ describe('catalogUI view toggle (grid/list)', () => {
     expect(localStorage.getItem('catalog-view-mode')).toBe('grid')
   })
 })
+
+describe('catalogUI active filter chips', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    history.replaceState(null, '', window.location.pathname)
+    setupDOM()
+    mockGetSession.mockResolvedValue({ user: { id: 'user-123' } })
+    mockOnAuthStateChange.mockImplementation(() => {})
+    mockGetLikeStates.mockResolvedValue(new Map())
+    mockGetWatchlistedImageIds.mockResolvedValue(new Set())
+    mockGetCogImages.mockResolvedValue({ data: [], totalCount: 0, error: null })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  async function initAndOpen() {
+    const onSelect = vi.fn()
+    initCatalogUI(onSelect)
+    await vi.advanceTimersByTimeAsync(0)
+    document.getElementById('catalog-toggle-btn').click()
+    await vi.advanceTimersByTimeAsync(0)
+  }
+
+  it('활성 필터가 없으면 칩 영역이 숨겨져 있다', async () => {
+    await initAndOpen()
+    const container = document.getElementById('catalog-active-filters')
+    expect(container).not.toBeNull()
+    expect(container.style.display).toBe('none')
+    expect(container.children.length).toBe(0)
+  })
+
+  it('검색어 입력 시 검색 칩이 표시된다', async () => {
+    await initAndOpen()
+    const searchInput = document.getElementById('catalog-search')
+    searchInput.value = '위성'
+    searchInput.dispatchEvent(new Event('input'))
+    await vi.advanceTimersByTimeAsync(300)
+    const container = document.getElementById('catalog-active-filters')
+    expect(container.style.display).not.toBe('none')
+    const chips = container.querySelectorAll('.catalog-filter-chip')
+    expect(chips.length).toBe(1)
+    expect(chips[0].textContent).toContain('검색: 위성')
+  })
+
+  it('출처 필터 선택 시 출처 칩이 표시된다', async () => {
+    await initAndOpen()
+    const sourceFilter = document.getElementById('catalog-filter-source')
+    sourceFilter.value = 'stac'
+    sourceFilter.dispatchEvent(new Event('change'))
+    await vi.advanceTimersByTimeAsync(300)
+    const chips = document.querySelectorAll('.catalog-filter-chip')
+    expect(chips.length).toBe(1)
+    expect(chips[0].textContent).toContain('출처: STAC')
+  })
+
+  it('칩 × 버튼 클릭 시 해당 필터가 해제된다', async () => {
+    await initAndOpen()
+    const searchInput = document.getElementById('catalog-search')
+    searchInput.value = '테스트'
+    searchInput.dispatchEvent(new Event('input'))
+    await vi.advanceTimersByTimeAsync(300)
+    const removeBtn = document.querySelector('.catalog-filter-chip-remove')
+    expect(removeBtn).not.toBeNull()
+    mockGetCogImages.mockClear()
+    removeBtn.click()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(searchInput.value).toBe('')
+    const container = document.getElementById('catalog-active-filters')
+    expect(container.style.display).toBe('none')
+  })
+
+  it('여러 필터 동시 활성 시 모든 칩이 표시된다', async () => {
+    await initAndOpen()
+    const searchInput = document.getElementById('catalog-search')
+    const tagFilter = document.getElementById('catalog-filter-tag')
+    const yearFilter = document.getElementById('catalog-filter-year')
+    searchInput.value = '검색어'
+    tagFilter.value = 'flood'
+    yearFilter.value = '2025'
+    yearFilter.dispatchEvent(new Event('change'))
+    await vi.advanceTimersByTimeAsync(300)
+    const chips = document.querySelectorAll('.catalog-filter-chip')
+    expect(chips.length).toBe(3)
+    const labels = Array.from(chips).map(c => c.textContent)
+    expect(labels.some(l => l.includes('검색:'))).toBe(true)
+    expect(labels.some(l => l.includes('태그: flood'))).toBe(true)
+    expect(labels.some(l => l.includes('연도: 2025'))).toBe(true)
+  })
+
+  it('필터 초기화 버튼 클릭 시 모든 칩이 제거된다', async () => {
+    await initAndOpen()
+    const searchInput = document.getElementById('catalog-search')
+    searchInput.value = '테스트'
+    searchInput.dispatchEvent(new Event('input'))
+    await vi.advanceTimersByTimeAsync(300)
+    const resetBtn = document.getElementById('catalog-filter-reset')
+    resetBtn.click()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(document.querySelectorAll('.catalog-filter-chip').length).toBe(0)
+    expect(document.getElementById('catalog-active-filters').style.display).toBe('none')
+  })
+})


### PR DESCRIPTION
## Summary
- 카탈로그 패널에서 활성화된 필터 조건을 칩(chip) 형태로 시각적으로 표시
- 각 칩의 × 버튼으로 개별 필터를 선택적으로 해제 가능
- 검색어, 출처, 태그, 연도, 내 등록만, 좋아요만 필터 칩 지원
- 기존 필터 초기화 버튼과 정상 공존 (개별 해제 vs 일괄 초기화)

## Test plan
- [x] 활성 필터가 없을 때 칩 영역 숨김 확인
- [x] 각 필터 조건별 칩 생성 확인
- [x] 칩 × 클릭 시 해당 필터 해제 및 목록 갱신 확인
- [x] 여러 필터 동시 활성 시 모든 칩 표시 확인
- [x] 필터 초기화 버튼 클릭 시 모든 칩 제거 확인
- [x] 단위 테스트 6개 추가, 전체 402 테스트 통과

closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)