### PR TITLE
feat: 카탈로그 검색창 단축키 (/ 키로 포커스)

### DIFF
--- a/src/catalogUI.js
+++ b/src/catalogUI.js
@@ -403,6 +403,25 @@ export function initCatalogUI(onSelectCog) {
     loadPage()
   })
 
+  // '/' 키로 검색창 포커스, Escape 키로 포커스 해제
+  document.addEventListener('keydown', (e) => {
+    if (e.key === '/' && !isInputFocused()) {
+      e.preventDefault()
+      searchInput.focus()
+      searchInput.select()
+    }
+    if (e.key === 'Escape' && document.activeElement === searchInput) {
+      searchInput.blur()
+    }
+  })
+
+  function isInputFocused() {
+    const el = document.activeElement
+    if (!el) return false
+    const tag = el.tagName.toLowerCase()
+    return tag === 'input' || tag === 'textarea' || tag === 'select' || el.isContentEditable
+  }
+
   // 등록 이벤트 수신 → 목록 갱신
   document.addEventListener('cog-registered', () => {
     if (panel.classList.contains('open')) {

--- a/tests/unit/catalogUI.test.js
+++ b/tests/unit/catalogUI.test.js
@@ -1860,3 +1860,80 @@ describe('catalogUI thumbnail lazy loading', () => {
     expect(document.querySelector('.catalog-card')).not.toBeNull()
   })
 })
+
+describe('catalogUI 검색창 단축키', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupDOM()
+    mockGetSession.mockResolvedValue(null)
+    mockOnAuthStateChange.mockImplementation(() => {})
+    mockGetCogImages.mockResolvedValue({ data: [], totalCount: 0, error: null })
+    mockGetLikeStates.mockResolvedValue(new Map())
+    mockGetWatchlistedImageIds.mockResolvedValue(new Set())
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('/ 키를 누르면 검색창에 포커스가 이동한다', async () => {
+    initCatalogUI(vi.fn())
+    await new Promise(r => setTimeout(r, 10))
+
+    const searchInput = document.getElementById('catalog-search')
+    expect(document.activeElement).not.toBe(searchInput)
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: '/' }))
+    expect(document.activeElement).toBe(searchInput)
+  })
+
+  it('/ 키를 누르면 기존 검색어가 전체 선택된다', async () => {
+    initCatalogUI(vi.fn())
+    await new Promise(r => setTimeout(r, 10))
+
+    const searchInput = document.getElementById('catalog-search')
+    searchInput.value = 'test query'
+    const selectSpy = vi.spyOn(searchInput, 'select')
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: '/' }))
+    expect(selectSpy).toHaveBeenCalled()
+  })
+
+  it('input에 포커스가 있을 때 / 키를 누르면 무시된다', async () => {
+    initCatalogUI(vi.fn())
+    await new Promise(r => setTimeout(r, 10))
+
+    const searchInput = document.getElementById('catalog-search')
+    searchInput.focus()
+
+    const preventDefaultSpy = vi.fn()
+    const event = new KeyboardEvent('keydown', { key: '/' })
+    // keydown 이벤트는 이미 dispatch된 후라 preventDefault를 spy할 수 없으므로
+    // 대신 포커스가 유지되는지 확인
+    document.dispatchEvent(event)
+    expect(document.activeElement).toBe(searchInput)
+  })
+
+  it('Escape 키를 누르면 검색창 포커스가 해제된다', async () => {
+    initCatalogUI(vi.fn())
+    await new Promise(r => setTimeout(r, 10))
+
+    const searchInput = document.getElementById('catalog-search')
+    searchInput.focus()
+    expect(document.activeElement).toBe(searchInput)
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    expect(document.activeElement).not.toBe(searchInput)
+  })
+
+  it('검색창에 포커스가 없을 때 Escape 키는 아무 동작도 하지 않는다', async () => {
+    initCatalogUI(vi.fn())
+    await new Promise(r => setTimeout(r, 10))
+
+    const searchInput = document.getElementById('catalog-search')
+    expect(document.activeElement).not.toBe(searchInput)
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    expect(document.activeElement).not.toBe(searchInput)
+  })
+})


### PR DESCRIPTION
## Summary
- `/` 키 입력 시 카탈로그 검색창(`#catalog-search`)으로 포커스 이동 및 기존 검색어 전체 선택
- input/textarea/select 등에 포커스 중일 때는 단축키 무시
- `Escape` 키로 검색창 포커스 해제(blur)
- 단위 테스트 5개 추가 (총 413개 통과)

closes #319

## Test plan
- [x] `/` 키 → 검색창 포커스 이동 테스트
- [x] `/` 키 → 기존 검색어 전체 선택 테스트
- [x] input 포커스 중 `/` 키 무시 테스트
- [x] `Escape` 키 → 포커스 해제 테스트
- [x] 검색창 미포커스 시 `Escape` 무동작 테스트
- [x] 기존 413개 테스트 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)