### PR TITLE
feat: 카탈로그 카드 키보드 접근성 개선 (tabIndex + Enter/Space)

### DIFF
--- a/src/catalogUI.js
+++ b/src/catalogUI.js
@@ -482,6 +482,15 @@ export function initCatalogUI(onSelectCog) {
     data.forEach(item => {
       const card = document.createElement('div')
       card.className = 'catalog-card' + (activeCardId === item.id ? ' catalog-card--active' : '')
+      card.tabIndex = 0
+      card.setAttribute('role', 'button')
+      card.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          if (e.target !== card) return
+          e.preventDefault()
+          card.click()
+        }
+      })
 
       const thumbHtml = item.thumbnail_url
         ? `<img src="${escapeHtml(item.thumbnail_url)}" class="catalog-card-thumb" alt="${escapeHtml(item.title || '영상')}" loading="lazy" onerror="this.style.display='none'">`

--- a/tests/unit/catalogUI.test.js
+++ b/tests/unit/catalogUI.test.js
@@ -1937,3 +1937,72 @@ describe('catalogUI 검색창 단축키', () => {
     expect(document.activeElement).not.toBe(searchInput)
   })
 })
+
+describe('catalogUI keyboard accessibility', () => {
+  const TEST_USER_ID = 'user-123'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupDOM()
+    mockGetSession.mockResolvedValue({ user: { id: TEST_USER_ID } })
+    mockOnAuthStateChange.mockImplementation(() => {})
+    mockGetLikeStates.mockResolvedValue(new Map())
+    mockGetWatchlistedImageIds.mockResolvedValue(new Set())
+  })
+
+  async function openPanelWithItems(items) {
+    mockGetCogImages.mockResolvedValue({ data: items, totalCount: items.length, error: null })
+    const onSelect = vi.fn()
+    initCatalogUI(onSelect)
+    await new Promise(r => setTimeout(r, 10))
+    document.getElementById('catalog-toggle-btn').click()
+    await new Promise(r => setTimeout(r, 10))
+    return onSelect
+  }
+
+  it('catalog cards have tabIndex=0 and role=button', async () => {
+    await openPanelWithItems([
+      { id: '1', user_id: TEST_USER_ID, title: 'Test', tags: [], created_at: '2026-01-01' },
+    ])
+
+    const card = document.querySelector('.catalog-card')
+    expect(card.tabIndex).toBe(0)
+    expect(card.getAttribute('role')).toBe('button')
+  })
+
+  it('Enter key on card triggers click (opens viewer)', async () => {
+    const onSelect = await openPanelWithItems([
+      { id: '1', user_id: TEST_USER_ID, title: 'Test', url: 'http://example.com/test.tif', tags: [], created_at: '2026-01-01' },
+    ])
+
+    const card = document.querySelector('.catalog-card')
+    card.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    await new Promise(r => setTimeout(r, 10))
+
+    expect(onSelect).toHaveBeenCalledWith('http://example.com/test.tif', expect.objectContaining({ id: '1' }))
+  })
+
+  it('Space key on card triggers click (opens viewer)', async () => {
+    const onSelect = await openPanelWithItems([
+      { id: '1', user_id: TEST_USER_ID, title: 'Test', url: 'http://example.com/test.tif', tags: [], created_at: '2026-01-01' },
+    ])
+
+    const card = document.querySelector('.catalog-card')
+    card.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }))
+    await new Promise(r => setTimeout(r, 10))
+
+    expect(onSelect).toHaveBeenCalledWith('http://example.com/test.tif', expect.objectContaining({ id: '1' }))
+  })
+
+  it('Enter/Space on inner button does not trigger card click', async () => {
+    const onSelect = await openPanelWithItems([
+      { id: '1', user_id: TEST_USER_ID, title: 'Test', url: 'http://example.com/test.tif', tags: [], created_at: '2026-01-01' },
+    ])
+
+    const shareBtn = document.querySelector('.catalog-share-btn')
+    shareBtn.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    await new Promise(r => setTimeout(r, 10))
+
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- 카탈로그 카드에 `tabIndex="0"`, `role="button"` 추가로 Tab 포커스 가능
- Enter/Space 키로 카드 열기(뷰어 로드) 지원
- 카드 내부 버튼(좋아요, 관심목록, 공유 등)은 독립적 Tab 접근 유지
- 단위 테스트 4건 추가 (총 417개 통과)

closes #323

## Test plan
- [ ] Tab 키로 카탈로그 카드 포커스 이동 확인
- [ ] Enter/Space로 카드 열기 동작 확인
- [ ] 카드 내 버튼 독립 Tab 접근 확인
- [ ] 기존 마우스 클릭 동작 정상 확인
- [ ] `npx vitest run` 전체 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)