### PR TITLE
feat: 카탈로그 로딩 중 스켈레톤 카드 UI 표시

### DIFF
--- a/index.html
+++ b/index.html
@@ -1482,6 +1482,43 @@
       color: #fff;
     }
 
+    /* Skeleton card shimmer */
+    @keyframes catalog-shimmer {
+      0% { background-position: -200px 0; }
+      100% { background-position: 200px 0; }
+    }
+
+    .catalog-skeleton-shimmer {
+      background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+      background-size: 400px 100%;
+      animation: catalog-shimmer 1.5s infinite linear;
+      border-radius: 4px;
+    }
+
+    .catalog-skeleton-thumb {
+      width: 100%;
+      height: 80px;
+      margin-bottom: 0.5rem;
+    }
+
+    .catalog-list--list-view .catalog-skeleton-thumb {
+      width: 60px;
+      height: 60px;
+      flex-shrink: 0;
+      margin-bottom: 0;
+    }
+
+    .catalog-skeleton-title {
+      height: 0.75rem;
+      width: 70%;
+      margin-bottom: 0.4rem;
+    }
+
+    .catalog-skeleton-tags {
+      height: 0.6rem;
+      width: 40%;
+    }
+
     .catalog-source-badge {
       display: inline-block;
       padding: 0.1rem 0.35rem;

--- a/src/catalogUI.js
+++ b/src/catalogUI.js
@@ -430,9 +430,33 @@ export function initCatalogUI(onSelectCog) {
     }
   })
 
+  function renderSkeletonCards(container, count, mode) {
+    container.innerHTML = ''
+    for (let i = 0; i < count; i++) {
+      const card = document.createElement('div')
+      card.className = 'catalog-card catalog-skeleton-card'
+      const body = document.createElement('div')
+      body.className = 'catalog-card-body'
+      const thumb = document.createElement('div')
+      thumb.className = 'catalog-skeleton-thumb catalog-skeleton-shimmer'
+      const info = document.createElement('div')
+      info.className = 'catalog-card-info'
+      const title = document.createElement('div')
+      title.className = 'catalog-skeleton-title catalog-skeleton-shimmer'
+      const tags = document.createElement('div')
+      tags.className = 'catalog-skeleton-tags catalog-skeleton-shimmer'
+      info.appendChild(title)
+      info.appendChild(tags)
+      body.appendChild(thumb)
+      body.appendChild(info)
+      card.appendChild(body)
+      container.appendChild(card)
+    }
+  }
+
   async function loadPage() {
     syncUrlToState()
-    listEl.innerHTML = '<div style="text-align:center;padding:2rem;color:#999;">로딩 중...</div>'
+    renderSkeletonCards(listEl, pageSize, viewMode)
 
     const offset = currentPage * pageSize
     const likedIds = likedOnlyCheckbox.checked ? await getLikedImageIds() : null

--- a/tests/unit/catalogUI.test.js
+++ b/tests/unit/catalogUI.test.js
@@ -2006,3 +2006,58 @@ describe('catalogUI keyboard accessibility', () => {
     expect(onSelect).not.toHaveBeenCalled()
   })
 })
+
+describe('스켈레톤 카드 UI', () => {
+  beforeEach(() => {
+    setupDOM()
+    mockGetSession.mockResolvedValue({ data: { session: null } })
+    mockOnAuthStateChange.mockReturnValue({ data: { subscription: { unsubscribe: vi.fn() } } })
+  })
+
+  afterEach(() => { vi.restoreAllMocks() })
+
+  it('로딩 시 pageSize 수만큼 스켈레톤 카드를 표시한다', async () => {
+    let resolveLoad
+    mockGetCogImages.mockReturnValue(new Promise(r => { resolveLoad = r }))
+
+    const onSelect = vi.fn()
+    initCatalogUI(onSelect)
+
+    document.getElementById('catalog-toggle-btn').click()
+    await new Promise(r => setTimeout(r, 50))
+
+    const skeletons = document.querySelectorAll('.catalog-skeleton-card')
+    expect(skeletons.length).toBe(20) // DEFAULT_PAGE_SIZE
+
+    resolveLoad({ data: [], totalCount: 0 })
+  })
+
+  it('스켈레톤 카드에 shimmer 클래스가 적용된다', async () => {
+    let resolveLoad
+    mockGetCogImages.mockReturnValue(new Promise(r => { resolveLoad = r }))
+
+    const onSelect = vi.fn()
+    initCatalogUI(onSelect)
+
+    document.getElementById('catalog-toggle-btn').click()
+    await new Promise(r => setTimeout(r, 50))
+
+    const shimmers = document.querySelectorAll('.catalog-skeleton-shimmer')
+    expect(shimmers.length).toBeGreaterThan(0)
+
+    resolveLoad({ data: [], totalCount: 0 })
+  })
+
+  it('데이터 로드 후 스켈레톤 카드가 제거된다', async () => {
+    mockGetCogImages.mockResolvedValue({ data: [], totalCount: 0 })
+
+    const onSelect = vi.fn()
+    initCatalogUI(onSelect)
+
+    document.getElementById('catalog-toggle-btn').click()
+    await new Promise(r => setTimeout(r, 50))
+
+    const skeletons = document.querySelectorAll('.catalog-skeleton-card')
+    expect(skeletons.length).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- 카탈로그 로딩 시 단순 "로딩 중..." 텍스트 대신 shimmer 애니메이션 스켈레톤 카드를 pageSize 수만큼 표시
- 그리드/리스트 뷰 모드 모두 지원하는 반응형 스켈레톤 레이아웃
- 단위 테스트 3개 추가 (스켈레톤 렌더링, shimmer 클래스, 데이터 로드 후 제거)

closes #327

## Test plan
- [x] 로딩 중 스켈레톤 카드가 pageSize(20) 수만큼 표시된다
- [x] 스켈레톤 카드에 shimmer 애니메이션 클래스가 적용된다
- [x] 데이터 로드 완료 후 실제 카드로 교체된다
- [x] 전체 테스트 420개 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)