### PR TITLE
feat: 카탈로그 카드 로드 시 페이드인 애니메이션 (closes #331)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1488,6 +1488,21 @@
       100% { background-position: 200px 0; }
     }
 
+    @keyframes catalog-fadeIn {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
+
+    .catalog-card--enter {
+      animation: catalog-fadeIn 200ms ease-out both;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .catalog-card--enter {
+        animation: none;
+      }
+    }
+
     .catalog-skeleton-shimmer {
       background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
       background-size: 400px 100%;

--- a/src/catalogUI.js
+++ b/src/catalogUI.js
@@ -505,7 +505,7 @@ export function initCatalogUI(onSelectCog) {
 
     data.forEach(item => {
       const card = document.createElement('div')
-      card.className = 'catalog-card' + (activeCardId === item.id ? ' catalog-card--active' : '')
+      card.className = 'catalog-card catalog-card--enter' + (activeCardId === item.id ? ' catalog-card--active' : '')
       card.tabIndex = 0
       card.setAttribute('role', 'button')
       card.addEventListener('keydown', (e) => {


### PR DESCRIPTION
## Summary
- 카탈로그 카드 렌더링 시 `catalog-card--enter` 클래스로 200ms fadeIn 애니메이션 적용
- `@keyframes catalog-fadeIn` (opacity 0→1) CSS 규칙 추가
- `prefers-reduced-motion: reduce` 환경에서 애니메이션 비활성화 (접근성)

## Test plan
- [x] 기존 테스트 420개 전체 통과
- [ ] 카탈로그 카드 렌더링 시 페이드인 애니메이션 확인 (그리드/리스트 뷰)
- [ ] `prefers-reduced-motion: reduce` 설정에서 애니메이션 생략 확인

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)